### PR TITLE
fix(docs): derive MCP page URLs from request origin

### DIFF
--- a/apps/docs/server/mcp/tools/get-page.ts
+++ b/apps/docs/server/mcp/tools/get-page.ts
@@ -19,7 +19,7 @@ WORKFLOW: This tool returns the complete page content including title, descripti
   cache: '1h',
   handler: async ({ path }) => {
     const event = useEvent()
-    const siteUrl = import.meta.dev ? 'http://localhost:3000' : 'https://mcp-toolkit.nuxt.dev'
+    const siteUrl = getRequestURL(event).origin
 
     try {
       const page = await queryCollection(event, 'docs')

--- a/apps/docs/server/mcp/tools/list-pages.ts
+++ b/apps/docs/server/mcp/tools/list-pages.ts
@@ -22,7 +22,7 @@ OUTPUT: Returns a structured list with:
   cache: '1h',
   handler: async () => {
     const event = useEvent()
-    const siteUrl = import.meta.dev ? 'http://localhost:3000' : getRequestURL(event).origin
+    const siteUrl = getRequestURL(event).origin
 
     try {
       const pages = await queryCollection(event, 'docs')


### PR DESCRIPTION
This makes the built-in MCP documentation tools return request-derived page URLs instead of hardcoded localhost URLs, so custom dev ports, previews, tunnels, and proxies work correctly.