### PR TITLE
fix: declare h3 as peer dependency for strict package managers

### DIFF
--- a/packages/nuxt-mcp-toolkit/package.json
+++ b/packages/nuxt-mcp-toolkit/package.json
@@ -60,10 +60,14 @@
     "tinyglobby": "^0.2.15"
   },
   "peerDependencies": {
+    "h3": "^1.15.0",
     "zod": "^4.1.13",
     "agents": ">=0.7.5"
   },
   "peerDependenciesMeta": {
+    "h3": {
+      "optional": false
+    },
     "zod": {
       "optional": false
     },


### PR DESCRIPTION
## What

Adds `h3` to `peerDependencies` in the `@nuxtjs/mcp-toolkit` package.

## Why

The runtime code () imports directly from `h3`:

```ts
import { getRouterParam } from 'h3'
import type { H3Event } from 'h3'
```

Under npm this resolves fine because h3 is installed transitively through Nuxt. But strict package managers like Deno require packages to explicitly declare all their imports — so `H3Event` and `event.context` types fail to resolve.

`h3 ^1.15.0` matches the version already shipped by `@nuxt/nitro-server` (which depends on `h3 ^1.15.6`), so any Nuxt 4 project already has it installed. This change just makes that dependency explicit.

Closes #148