### PR TITLE
refactor(module)/codemode improvements combined

### DIFF
--- a/apps/docs/content/1.getting-started/2.installation.md
+++ b/apps/docs/content/1.getting-started/2.installation.md
@@ -44,6 +44,8 @@ This will give you access to prompts like `setup-mcp-server`, `create-tool`, `cr
 - Node.js 18.x or higher
 - A package manager (npm, pnpm, yarn, or bun)
 
+If you enable Code Mode, that feature specifically requires Node.js `>=18.16.0`.
+
 ## Installation
 
 ::steps

--- a/apps/docs/content/2.core-concepts/5.handlers.md
+++ b/apps/docs/content/2.core-concepts/5.handlers.md
@@ -236,6 +236,8 @@ export default defineMcpHandler({
 })
 ```
 
+Code Mode requires `secure-exec` and Node.js `>=18.16.0`.
+
 ::callout{icon="i-lucide-book-open" color="primary"}
 See the [Code Mode guide](/advanced/code-mode) for full documentation, security details, and configuration options.
 ::

--- a/apps/docs/content/3.advanced/8.code-mode.md
+++ b/apps/docs/content/3.advanced/8.code-mode.md
@@ -98,6 +98,10 @@ bun add secure-exec
 
 ::
 
+::callout{icon="i-lucide-info" color="info"}
+Code Mode requires `secure-exec` and Node.js `>=18.16.0`. The rest of the module still supports Node.js 18.x, but code mode depends on `AsyncLocalStorage.snapshot()` to preserve request context.
+::
+
 ### 2. Enable on a handler
 
 Add `experimental_codeMode` to any handler:
@@ -194,6 +198,10 @@ export default defineMcpHandler({
     memoryLimit: 64,
     cpuTimeLimitMs: 10_000,
     maxResultSize: 102_400,
+    maxRequestBodyBytes: 1_048_576,
+    maxToolResponseSize: 1_048_576,
+    wallTimeLimitMs: 60_000,
+    maxToolCalls: 200,
     progressive: false,
     description: undefined,
   },
@@ -217,6 +225,30 @@ export default defineMcpHandler({
     Default: `102400` (100 KB)
 
     Maximum result size in bytes before truncation. Large results are intelligently truncated — arrays by number of items, objects by number of keys.
+  ::
+
+  ::field{name="maxRequestBodyBytes" type="number"}
+    Default: `1048576` (1 MB)
+
+    Maximum bytes accepted in a single RPC request body from the sandbox. Returns HTTP 413 if exceeded. Prevents memory exhaustion from oversized payloads.
+  ::
+
+  ::field{name="maxToolResponseSize" type="number"}
+    Default: `1048576` (1 MB)
+
+    Maximum bytes for individual tool RPC responses. Large results are truncated using the same strategy as `maxResultSize`.
+  ::
+
+  ::field{name="wallTimeLimitMs" type="number"}
+    Default: `60000` (60 seconds)
+
+    Wall-clock timeout for the entire execution. Unlike `cpuTimeLimitMs` which only covers CPU time in the isolate, this caps total elapsed time including host-side tool calls. Returns HTTP 408 on timeout.
+  ::
+
+  ::field{name="maxToolCalls" type="number"}
+    Default: `200`
+
+    Maximum number of tool RPC calls per execution. Prevents runaway loops that repeatedly invoke expensive tools. Returns HTTP 429 when exceeded.
   ::
 
   ::field{name="progressive" type="boolean"}
@@ -328,8 +360,12 @@ This prevents other local processes from calling your MCP tools through the RPC 
 | Resource | Default | Configurable | Protection |
 |----------|---------|-------------|------------|
 | **CPU time** | 10 seconds | `cpuTimeLimitMs` | Sandbox is killed on timeout — prevents infinite loops |
+| **Wall-clock time** | 60 seconds | `wallTimeLimitMs` | Caps total elapsed time including tool calls |
 | **Memory** | 64 MB | `memoryLimit` | V8 isolate hard limit — prevents OOM crashes |
 | **Result size** | 100 KB | `maxResultSize` | Intelligent truncation (arrays by items, objects by keys) |
+| **Tool response size** | 1 MB | `maxToolResponseSize` | Per-call truncation before response delivery |
+| **Request body size** | 1 MB | `maxRequestBodyBytes` | HTTP 413 early rejection — prevents memory exhaustion |
+| **Tool calls per execution** | 200 | `maxToolCalls` | HTTP 429 rate limit — prevents runaway loops |
 | **Log entries** | 200 | No | Console output capped — prevents `console.log` flooding |
 
 ### Input Validation
@@ -339,6 +375,10 @@ Tool names are interpolated into the sandbox code template. To prevent code inje
 - **Strict identifier regex** — Every tool name is validated against `/^[\w$]+$/` before being injected into the sandbox template.
 - **Sanitization** — Names are sanitized upstream (`get-user` → `get_user`), but a second validation layer at the template level ensures defense in depth.
 - **Rejection** — If a name fails validation, the execution throws immediately — no partial injection.
+
+### Error Sanitization
+
+Infrastructure errors (file paths, stack traces) are sanitized before being returned to the sandbox or the MCP client. Full error details are logged server-side with the `[nuxt-mcp-toolkit]` prefix for debugging.
 
 ### Summary
 

--- a/apps/docs/content/3.advanced/8.code-mode.md
+++ b/apps/docs/content/3.advanced/8.code-mode.md
@@ -260,9 +260,31 @@ export default defineMcpHandler({
   ::field{name="description" type="string"}
     Default: built-in template
 
-    Custom description for the `code` tool. Supports `{{types}}` and `{{count}}` placeholders.
+    Custom description for the `code` tool. Supports `{{types}}`, `{{count}}`, and `{{example}}` placeholders.
   ::
 ::
+
+## Annotation Surfacing
+
+MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`) are automatically surfaced as tags in code mode type signatures and search results:
+
+```typescript
+export default defineMcpTool({
+  name: 'delete-runbook',
+  description: 'Delete a runbook',
+  inputSchema: { id: z.string() },
+  annotations: { destructiveHint: true },
+  handler: async ({ id }) => { /* ... */ },
+})
+```
+
+This produces a type signature like:
+
+```typescript
+delete_runbook: (input: { id: string }) => Promise<unknown>; // [destructive] Delete a runbook
+```
+
+Available tags: `[read-only]`, `[destructive]`, `[idempotent]`. Tags are shown when the tool has annotations set.
 
 ## Progressive Mode
 
@@ -277,6 +299,23 @@ export default defineMcpHandler({
     progressive: true,
   },
 })
+```
+
+When tools have a `group` field, search results are grouped by section with annotation tags:
+
+```txt
+search({ query: "runbook" }) →
+
+Found 3/6 tools matching "runbook":
+
+## workspace
+
+codemode.create_runbook: (...) => Promise<{ ok: boolean; data: { id: string } }>;
+codemode.delete_runbook: (input: { id: string }) => Promise<unknown>; // [destructive] Irreversible
+
+## public
+
+codemode.search_public: (input: { q: string }) => Promise<Runbook[]>; // [read-only] Full-text search
 ```
 
 The LLM workflow becomes:
@@ -319,7 +358,7 @@ Always combine related operations into a single code block.`,
 })
 ```
 
-The `{{types}}` placeholder is replaced with the generated TypeScript definitions. The `{{count}}` placeholder is replaced with the number of available tools.
+Available placeholders: `{{types}}` (TypeScript definitions), `{{count}}` (tool count), `{{example}}` (usage example).
 
 In progressive mode, `{{types}}` is not available since types are discovered via the `search` tool.
 

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.cloudflare.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.cloudflare.ts
@@ -20,6 +20,7 @@ export async function execute(
       + '(requires Node.js: secure-exec, node:http). Use a Node.js deployment target '
       + 'or disable experimental_codeMode.',
     logs: [],
+    durationMs: 0,
   }
 }
 

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.ts
@@ -9,7 +9,7 @@ export { normalizeCode }
 
 type DispatchFn = (args: unknown) => Promise<unknown>
 
-const ERROR_PREFIX = '__ERROR__'
+const ERROR_PREFIX = '__MCP_EXEC_ERR__'
 const DEFAULT_MAX_RESULT_SIZE = 102_400
 const DEFAULT_MAX_REQUEST_BODY_BYTES = 1_048_576
 const DEFAULT_MAX_TOOL_RESPONSE_SIZE = 1_048_576
@@ -241,6 +241,8 @@ async function createRpcSession(
         execId,
         maxRequestBodyBytes,
         token,
+      }).catch(() => {
+        if (!res.headersSent) res.destroy()
       })
     })
 
@@ -248,7 +250,8 @@ async function createRpcSession(
       try {
         server.close()
       }
-      catch {
+      catch (closeError) {
+        console.warn('[nuxt-mcp-toolkit] server.close() failed during error handling:', closeError)
       }
       reject(error)
     }
@@ -269,15 +272,7 @@ async function createRpcSession(
   })
 }
 
-let cachedProxyKey = ''
-let cachedProxyCode = ''
-
 function getProxyBoilerplate(toolNames: string[], port: number, token: string): string {
-  const key = `${port}:${token}:${toolNames.join(',')}`
-  if (key === cachedProxyKey) {
-    return cachedProxyCode
-  }
-
   for (const name of toolNames) {
     if (!SAFE_IDENTIFIER.test(name)) {
       throw new Error(`[nuxt-mcp-toolkit] Unsafe tool name rejected: "${name}"`)
@@ -288,7 +283,7 @@ function getProxyBoilerplate(toolNames: string[], port: number, token: string): 
     .map(name => `  ${name}: (input) => rpc('${name}', input)`)
     .join(',\n')
 
-  cachedProxyCode = `
+  return `
 async function rpc(toolName, args) {
   const res = await fetch('http://127.0.0.1:${port}', {
     method: 'POST',
@@ -297,7 +292,7 @@ async function rpc(toolName, args) {
   });
   const data = JSON.parse(typeof res.text === 'function' ? await res.text() : res.body);
   if (data.error) throw new Error(data.error);
-  if (data.result && data.result.__toolError) {
+  if (data.result && data.result.__mcp_toolkit_error__) {
     const err = new Error(data.result.message);
     err.tool = data.result.tool;
     err.isToolError = true;
@@ -310,8 +305,6 @@ async function rpc(toolName, args) {
 const codemode = {
 ${proxyMethods}
 };`
-  cachedProxyKey = key
-  return cachedProxyCode
 }
 
 function buildSandboxCode(
@@ -410,7 +403,8 @@ export async function execute(
         try {
           runtime.dispose()
         }
-        catch {
+        catch (disposeError) {
+          console.warn('[nuxt-mcp-toolkit] runtime.dispose() failed during cleanup:', disposeError)
         }
         runtime = null
       }
@@ -418,7 +412,8 @@ export async function execute(
         try {
           rpcSession.server.close()
         }
-        catch {
+        catch (closeError) {
+          console.warn('[nuxt-mcp-toolkit] server.close() failed during cleanup:', closeError)
         }
         rpcSession = null
       }
@@ -469,7 +464,8 @@ export async function execute(
       try {
         runtime?.dispose()
       }
-      catch {
+      catch (disposeError) {
+        console.warn('[nuxt-mcp-toolkit] runtime.dispose() failed during wall-time timeout:', disposeError)
       }
     }, wallTimeLimitMs)
 
@@ -548,6 +544,7 @@ export async function execute(
     }
   }
   catch (error) {
+    console.error('[nuxt-mcp-toolkit] Execution error:', error)
     return {
       result: undefined,
       error: sanitizeErrorMessage(getErrorMessage(error)),
@@ -568,6 +565,4 @@ export function dispose(): void {
   }
 
   secureExecModule = null
-  cachedProxyKey = ''
-  cachedProxyCode = ''
 }

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.ts
@@ -1,6 +1,6 @@
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
-import { randomBytes } from 'node:crypto'
 import { AsyncLocalStorage } from 'node:async_hooks'
+import { randomBytes } from 'node:crypto'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import type { CodeModeOptions, ExecuteResult } from './types'
 import { normalizeCode } from './normalize-code'
 
@@ -10,29 +10,69 @@ export { normalizeCode }
 type DispatchFn = (args: unknown) => Promise<unknown>
 
 const ERROR_PREFIX = '__ERROR__'
-const DEFAULT_MAX_RESULT_SIZE = 102_400 // 100KB
-const DEFAULT_MAX_REQUEST_BODY_BYTES = 1_048_576 // 1MB
-const DEFAULT_MAX_TOOL_RESPONSE_SIZE = 1_048_576 // 1MB
-const DEFAULT_WALL_TIME_LIMIT_MS = 60_000 // 60s
+const DEFAULT_MAX_RESULT_SIZE = 102_400
+const DEFAULT_MAX_REQUEST_BODY_BYTES = 1_048_576
+const DEFAULT_MAX_TOOL_RESPONSE_SIZE = 1_048_576
+const DEFAULT_WALL_TIME_LIMIT_MS = 60_000
 const DEFAULT_MAX_TOOL_CALLS = 200
+const DEFAULT_MEMORY_LIMIT = 64
+const DEFAULT_CPU_TIME_LIMIT_MS = 10_000
 const MAX_LOG_ENTRIES = 200
 const RETURN_TOOL = '__return__'
+const SAFE_IDENTIFIER = /^[\w$]+$/
+
+interface ExecutionContext {
+  fns: Record<string, DispatchFn>
+  onReturn: (value: unknown) => void
+  restoreContext: <R, TArgs extends unknown[]>(fn: (...args: TArgs) => R, ...args: TArgs) => R
+  deadlineMs: number
+  returned: boolean
+  rpcCallCount: number
+  maxToolCalls: number
+  maxToolResponseSize: number
+}
+
+interface RpcSession {
+  execId: string
+  port: number
+  server: Server
+  token: string
+  maxRequestBodyBytes: number
+  context: ExecutionContext
+}
+
+interface ActiveSession {
+  cleanup: () => void
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let secureExecModule: any = null
+const activeSessions = new Set<ActiveSession>()
 
 async function loadSecureExec() {
   if (secureExecModule) return secureExecModule
+
   try {
     secureExecModule = await import('secure-exec')
     return secureExecModule
   }
-  catch (error) {
-    console.error('[nuxt-mcp-toolkit] Failed to load secure-exec:', error)
+  catch {
     throw new Error(
       '[nuxt-mcp-toolkit] Code Mode requires `secure-exec`. Install it with: npm install secure-exec',
     )
   }
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function sanitizeErrorMessage(msg: string): string {
+  return msg
+    .replace(/(?:\/[\w.][-\w.]*)+\.\w+/g, '[path]')
+    .replace(/(?:[A-Z]:\\[\w.][-\w.\\]*)+/g, '[path]')
+    .replace(/\n\s+at .+/g, '')
+    .slice(0, 500)
 }
 
 function createRpcOnlyAdapter(allowedPort: number) {
@@ -46,22 +86,22 @@ function createRpcOnlyAdapter(allowedPort: number) {
         throw new Error(`Network access restricted to RPC server (blocked port: ${parsed.port})`)
       }
 
-      const resp = await globalThis.fetch(url, {
+      const response = await globalThis.fetch(url, {
         method: options?.method || 'GET',
         headers: options?.headers,
         body: options?.body,
         redirect: 'error',
       })
-      const body = await resp.text()
+      const body = await response.text()
       const headers: Record<string, string> = {}
-      resp.headers.forEach((v, k) => {
-        headers[k] = v
+      response.headers.forEach((value, key) => {
+        headers[key] = value
       })
 
       return {
-        ok: resp.ok,
-        status: resp.status,
-        statusText: resp.statusText,
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
         headers,
         body,
         url,
@@ -79,81 +119,26 @@ function createRpcOnlyAdapter(allowedPort: number) {
   }
 }
 
-interface ExecutionContext {
-  fns: Record<string, DispatchFn>
-  onReturn?: (value: unknown) => void
-  returned: boolean
-  /**
-   * Function returned by AsyncLocalStorage.snapshot() that re-enters the
-   * async context active when execute() was called, before invoking the
-   * provided callback.
-   */
-  restoreContext: <R, TArgs extends unknown[]>(fn: (...args: TArgs) => R, ...args: TArgs) => R
-  deadlineMs: number
-  rpcCallCount: number
-  maxToolCalls: number
-  maxToolResponseSize: number
-}
-
-interface RpcState {
-  server: Server
-  readonly port: number
-  readonly token: string
-  readonly executions: Map<string, ExecutionContext>
-  readonly maxRequestBodyBytes: number
-}
-
-let rpcState: RpcState | null = null
-let rpcStatePromise: Promise<RpcState> | null = null
-
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
-}
-
-function sanitizeErrorMessage(msg: string): string {
-  return msg
-    .replace(/(?:\/[\w.][-\w.]*)+\.\w+/g, '[path]')
-    .replace(/(?:[A-Z]:\\[\w.][-\w.\\]*)+/g, '[path]')
-    .replace(/\n\s+at .+/g, '')
-    .slice(0, 500)
-}
-
 function sendJson(
   res: ServerResponse,
   status: number,
   payload: Record<string, unknown>,
 ): void {
-  let serialized: string
-  try {
-    serialized = JSON.stringify(payload)
-  }
-  catch (error) {
-    console.warn('[nuxt-mcp-toolkit] Failed to serialize RPC response:', getErrorMessage(error))
-    if (res.headersSent) {
-      res.destroy()
-      return
-    }
-    serialized = JSON.stringify({ error: 'Failed to serialize RPC response' })
-    status = 500
-  }
-
   try {
     res.writeHead(status, { 'Content-Type': 'application/json' })
-    res.end(serialized)
+    res.end(JSON.stringify(payload))
   }
   catch (error) {
-    console.warn('[nuxt-mcp-toolkit] Failed to write RPC response:', getErrorMessage(error))
-    if (res.headersSent) {
-      res.destroy()
-      return
+    if (!res.headersSent) {
+      try {
+        res.writeHead(500, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: sanitizeErrorMessage(getErrorMessage(error)) }))
+      }
+      catch {
+        res.destroy()
+      }
     }
-
-    try {
-      res.writeHead(500, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ error: 'Failed to send RPC response' }))
-    }
-    catch (innerError) {
-      console.warn('[nuxt-mcp-toolkit] RPC response write failed, destroying socket:', getErrorMessage(innerError))
+    else {
       res.destroy()
     }
   }
@@ -162,9 +147,9 @@ function sendJson(
 async function handleRpcRequest(
   req: IncomingMessage,
   res: ServerResponse,
-  state: Pick<RpcState, 'token' | 'executions' | 'maxRequestBodyBytes'>,
+  session: Pick<RpcSession, 'context' | 'execId' | 'maxRequestBodyBytes' | 'token'>,
 ): Promise<void> {
-  if (req.headers['x-rpc-token'] !== state.token) {
+  if (req.headers['x-rpc-token'] !== session.token) {
     sendJson(res, 403, { error: 'Forbidden' })
     return
   }
@@ -172,17 +157,18 @@ async function handleRpcRequest(
   try {
     let body = ''
     let byteCount = 0
+
     for await (const chunk of req) {
-      const str = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString()
-      byteCount += Buffer.byteLength(str)
-      if (byteCount > state.maxRequestBodyBytes) {
+      const text = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString()
+      byteCount += Buffer.byteLength(text)
+      if (byteCount > session.maxRequestBodyBytes) {
         sendJson(res, 413, { error: 'Request body exceeds size limit' })
         return
       }
-      body += str
+      body += text
     }
 
-    const { tool: name, args, execId } = JSON.parse(body) as {
+    const { tool, args, execId } = JSON.parse(body) as {
       tool: string
       args: unknown
       execId: string
@@ -193,115 +179,104 @@ async function handleRpcRequest(
       return
     }
 
-    const exec = state.executions.get(execId)
-    if (!exec) {
+    if (execId !== session.execId) {
       sendJson(res, 400, { error: `Unknown execution: ${execId}` })
       return
     }
 
-    if (Date.now() > exec.deadlineMs) {
+    if (Date.now() > session.context.deadlineMs) {
       sendJson(res, 408, { error: 'Execution wall-clock timeout exceeded' })
       return
     }
 
-    if (name === RETURN_TOOL) {
-      if (!exec.onReturn) {
-        sendJson(res, 400, { error: `Execution cannot accept return value: ${execId}` })
-        return
-      }
-      if (exec.returned) {
+    if (tool === RETURN_TOOL) {
+      if (session.context.returned) {
         sendJson(res, 400, { error: 'Return value already received for this execution' })
         return
       }
 
-      exec.restoreContext(exec.onReturn, args)
-      exec.returned = true
+      session.context.restoreContext(session.context.onReturn, args)
+      session.context.returned = true
       sendJson(res, 200, { result: { ok: true } })
       return
     }
 
-    const fn = exec.fns[name]
+    const fn = session.context.fns[tool]
     if (!fn) {
-      sendJson(res, 400, { error: `Unknown tool: ${name}` })
+      sendJson(res, 400, { error: `Unknown tool: ${tool}` })
       return
     }
 
-    exec.rpcCallCount++
-    if (exec.rpcCallCount > exec.maxToolCalls) {
-      sendJson(res, 429, { error: `Tool call limit exceeded (max ${exec.maxToolCalls})` })
+    session.context.rpcCallCount += 1
+    if (session.context.rpcCallCount > session.context.maxToolCalls) {
+      sendJson(res, 429, { error: `Tool call limit exceeded (max ${session.context.maxToolCalls})` })
       return
     }
 
-    const result = await exec.restoreContext(fn, args)
+    const result = await session.context.restoreContext(fn, args)
     const serialized = JSON.stringify(result)
-    if (serialized.length > exec.maxToolResponseSize) {
-      sendJson(res, 200, { result: truncateResult(result, serialized.length, exec.maxToolResponseSize) })
+    if (serialized.length > session.context.maxToolResponseSize) {
+      sendJson(res, 200, { result: truncateResult(result, serialized.length, session.context.maxToolResponseSize) })
+      return
     }
-    else {
-      sendJson(res, 200, { result })
-    }
+
+    sendJson(res, 200, { result })
   }
   catch (error) {
-    console.error('[nuxt-mcp-toolkit] RPC dispatch error:', error)
     sendJson(res, 500, { error: sanitizeErrorMessage(getErrorMessage(error)) })
   }
 }
 
-function ensureRpcServer(maxRequestBodyBytes: number): Promise<RpcState> {
-  if (rpcState) return Promise.resolve(rpcState)
-  if (rpcStatePromise) return rpcStatePromise
+async function createRpcSession(
+  context: ExecutionContext,
+  maxRequestBodyBytes: number,
+): Promise<RpcSession> {
+  const execId = randomBytes(8).toString('hex')
+  const token = randomBytes(32).toString('hex')
 
-  rpcStatePromise = new Promise((resolve, reject) => {
-    const token = randomBytes(32).toString('hex')
-    const executions = new Map<string, ExecutionContext>()
-    const stateRef = { token, executions, maxRequestBodyBytes }
+  return await new Promise<RpcSession>((resolve, reject) => {
     const server = createServer((req, res) => {
-      handleRpcRequest(req, res, stateRef).catch((error) => {
-        console.error('[nuxt-mcp-toolkit] Unhandled RPC error:', error)
-        if (!res.headersSent) {
-          try {
-            sendJson(res, 500, { error: 'Internal server error' })
-          }
-          catch {
-            res.destroy()
-          }
-        }
+      void handleRpcRequest(req, res, {
+        context,
+        execId,
+        maxRequestBodyBytes,
+        token,
       })
     })
 
     const onError = (error: Error) => {
-      rpcStatePromise = null
-      console.error('[nuxt-mcp-toolkit] RPC server startup failed:', error)
       try {
         server.close()
       }
-      catch (closeError) {
-        console.warn('[nuxt-mcp-toolkit] Failed to close RPC server during error cleanup:', getErrorMessage(closeError))
+      catch {
       }
       reject(error)
     }
 
     server.once('error', onError)
     server.listen(0, '127.0.0.1', () => {
-      const addr = server.address() as { port: number }
       server.off('error', onError)
-      const state: RpcState = { server, port: addr.port, token, executions, maxRequestBodyBytes }
-      rpcState = state
-      resolve(state)
+      const address = server.address() as { port: number }
+      resolve({
+        execId,
+        port: address.port,
+        server,
+        token,
+        maxRequestBodyBytes,
+        context,
+      })
     })
   })
-
-  return rpcStatePromise
 }
 
 let cachedProxyKey = ''
 let cachedProxyCode = ''
 
-const SAFE_IDENTIFIER = /^[\w$]+$/
-
 function getProxyBoilerplate(toolNames: string[], port: number, token: string): string {
   const key = `${port}:${token}:${toolNames.join(',')}`
-  if (key === cachedProxyKey) return cachedProxyCode
+  if (key === cachedProxyKey) {
+    return cachedProxyCode
+  }
 
   for (const name of toolNames) {
     if (!SAFE_IDENTIFIER.test(name)) {
@@ -364,9 +339,6 @@ __fn().then(
 `
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let runtimeInstance: any = null
-
 function truncateResult(value: unknown, totalSize: number, maxSize: number): Record<string, unknown> {
   if (Array.isArray(value)) {
     const keepCount = Math.max(1, Math.floor(value.length * maxSize / totalSize))
@@ -378,6 +350,7 @@ function truncateResult(value: unknown, totalSize: number, maxSize: number): Rec
       data: value.slice(0, keepCount),
     }
   }
+
   if (typeof value === 'object' && value !== null) {
     const keys = Object.keys(value)
     const keepCount = Math.max(1, Math.floor(keys.length * maxSize / totalSize))
@@ -393,6 +366,7 @@ function truncateResult(value: unknown, totalSize: number, maxSize: number): Rec
       data: partial,
     }
   }
+
   return {
     _truncated: true,
     _totalBytes: totalSize,
@@ -406,6 +380,7 @@ export async function execute(
   fns: Record<string, DispatchFn>,
   options?: CodeModeOptions,
 ): Promise<ExecuteResult> {
+  const startedAt = Date.now()
   const logs: string[] = []
 
   if (typeof AsyncLocalStorage.snapshot !== 'function') {
@@ -413,73 +388,143 @@ export async function execute(
       result: undefined,
       error: '[nuxt-mcp-toolkit] Code Mode requires Node.js >=18.16.0 (AsyncLocalStorage.snapshot is unavailable).',
       logs,
+      durationMs: Date.now() - startedAt,
     }
   }
 
-  let rpc: RpcState | undefined
-  let execId: string | undefined
-  let returnedResult: { value: unknown, received: boolean } = { value: undefined, received: false }
+  const restoreContext = AsyncLocalStorage.snapshot()
+  let returnedResult: { received: boolean, value: unknown } = { received: false, value: undefined }
+  let rpcSession: RpcSession | null = null
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let runtime: any = null
+  let wallTimer: ReturnType<typeof setTimeout> | undefined
+  let wallTimeExceeded = false
+
+  const activeSession: ActiveSession = {
+    cleanup: () => {
+      if (wallTimer) {
+        clearTimeout(wallTimer)
+        wallTimer = undefined
+      }
+      if (runtime) {
+        try {
+          runtime.dispose()
+        }
+        catch {
+        }
+        runtime = null
+      }
+      if (rpcSession) {
+        try {
+          rpcSession.server.close()
+        }
+        catch {
+        }
+        rpcSession = null
+      }
+    },
+  }
+
+  activeSessions.add(activeSession)
 
   try {
     const secureExec = await loadSecureExec()
-    rpc = await ensureRpcServer(options?.maxRequestBodyBytes ?? DEFAULT_MAX_REQUEST_BODY_BYTES)
+    const wallTimeLimitMs = options?.wallTimeLimitMs ?? DEFAULT_WALL_TIME_LIMIT_MS
+    const maxRequestBodyBytes = options?.maxRequestBodyBytes ?? DEFAULT_MAX_REQUEST_BODY_BYTES
+    const maxToolCalls = options?.maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS
+    const maxToolResponseSize = options?.maxToolResponseSize ?? DEFAULT_MAX_TOOL_RESPONSE_SIZE
 
-    execId = randomBytes(8).toString('hex')
-    const restoreContext = AsyncLocalStorage.snapshot()
-
-    // Result delivered via RPC per execution, avoiding console.log buffer limits (~4KB)
-    rpc.executions.set(execId, {
+    const executionContext: ExecutionContext = {
       fns: Object.freeze({ ...fns }),
       onReturn: (value: unknown) => {
-        returnedResult = { value, received: true }
+        returnedResult = { received: true, value }
       },
-      returned: false,
       restoreContext,
-      deadlineMs: Date.now() + (options?.wallTimeLimitMs ?? DEFAULT_WALL_TIME_LIMIT_MS),
+      deadlineMs: startedAt + wallTimeLimitMs,
+      returned: false,
       rpcCallCount: 0,
-      maxToolCalls: options?.maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS,
-      maxToolResponseSize: options?.maxToolResponseSize ?? DEFAULT_MAX_TOOL_RESPONSE_SIZE,
-    })
-
-    const toolNames = Object.keys(fns)
-    const sandboxCode = buildSandboxCode(code, toolNames, rpc.port, rpc.token, execId)
-
-    // Runtime is a singleton — memoryLimit and cpuTimeLimitMs are locked
-    // from the first call. Call dispose() and re-execute to change them.
-    if (!runtimeInstance) {
-      runtimeInstance = new secureExec.NodeRuntime({
-        systemDriver: secureExec.createNodeDriver({
-          networkAdapter: createRpcOnlyAdapter(rpc.port),
-          permissions: {
-            network: () => ({ allow: true }),
-          },
-        }),
-        runtimeDriverFactory: secureExec.createNodeRuntimeDriverFactory(),
-        memoryLimit: options?.memoryLimit ?? 64,
-        cpuTimeLimitMs: options?.cpuTimeLimitMs ?? 10_000,
-      })
+      maxToolCalls,
+      maxToolResponseSize,
     }
 
-    let errorMsg: string | undefined
-    const execResult = await runtimeInstance.exec(sandboxCode, {
-      onStdio: ({ channel, message }: { channel: string, message: string }) => {
-        if (channel === 'stderr' && message.startsWith(ERROR_PREFIX)) {
-          errorMsg = message.slice(ERROR_PREFIX.length)
-        }
-        else if (logs.length < MAX_LOG_ENTRIES) {
-          logs.push(`[${channel}] ${message}`)
-        }
-        else if (logs.length === MAX_LOG_ENTRIES) {
-          logs.push(`... log output truncated at ${MAX_LOG_ENTRIES} entries`)
-        }
-      },
+    rpcSession = await createRpcSession(executionContext, maxRequestBodyBytes)
+
+    runtime = new secureExec.NodeRuntime({
+      systemDriver: secureExec.createNodeDriver({
+        networkAdapter: createRpcOnlyAdapter(rpcSession.port),
+        permissions: {
+          network: () => ({ allow: true }),
+        },
+      }),
+      runtimeDriverFactory: secureExec.createNodeRuntimeDriverFactory(),
+      memoryLimit: options?.memoryLimit ?? DEFAULT_MEMORY_LIMIT,
+      cpuTimeLimitMs: options?.cpuTimeLimitMs ?? DEFAULT_CPU_TIME_LIMIT_MS,
     })
+
+    const sandboxCode = buildSandboxCode(code, Object.keys(fns), rpcSession.port, rpcSession.token, rpcSession.execId)
+
+    let errorMsg: string | undefined
+    wallTimer = setTimeout(() => {
+      wallTimeExceeded = true
+      try {
+        runtime?.dispose()
+      }
+      catch {
+      }
+    }, wallTimeLimitMs)
+
+    let execResult: { code: number, errorMessage?: string }
+    try {
+      execResult = await runtime.exec(sandboxCode, {
+        onStdio: ({ channel, message }: { channel: string, message: string }) => {
+          if (channel === 'stderr' && message.startsWith(ERROR_PREFIX)) {
+            errorMsg = message.slice(ERROR_PREFIX.length).trimEnd()
+            return
+          }
+
+          if (logs.length < MAX_LOG_ENTRIES) {
+            logs.push(`[${channel}] ${message}`)
+          }
+          else if (logs.length === MAX_LOG_ENTRIES) {
+            logs.push(`... log output truncated at ${MAX_LOG_ENTRIES} entries`)
+          }
+        },
+      })
+    }
+    catch (error) {
+      if (wallTimeExceeded) {
+        return {
+          result: undefined,
+          error: 'Execution wall-clock timeout exceeded',
+          logs,
+          durationMs: Date.now() - startedAt,
+        }
+      }
+
+      throw error
+    }
+    finally {
+      if (wallTimer) {
+        clearTimeout(wallTimer)
+        wallTimer = undefined
+      }
+    }
+
+    if (wallTimeExceeded) {
+      return {
+        result: undefined,
+        error: 'Execution wall-clock timeout exceeded',
+        logs,
+        durationMs: Date.now() - startedAt,
+      }
+    }
 
     if (execResult.code !== 0 || errorMsg) {
       return {
         result: undefined,
         error: errorMsg ?? execResult.errorMessage ?? `Exit code ${execResult.code}`,
         logs,
+        durationMs: Date.now() - startedAt,
       }
     }
 
@@ -496,46 +541,32 @@ export async function execute(
       }
     }
 
-    return { result, logs }
+    return {
+      result,
+      logs,
+      durationMs: Date.now() - startedAt,
+    }
   }
   catch (error) {
-    console.error('[nuxt-mcp-toolkit] Execution error:', error)
     return {
       result: undefined,
       error: sanitizeErrorMessage(getErrorMessage(error)),
       logs,
+      durationMs: Date.now() - startedAt,
     }
   }
   finally {
-    if (rpc && execId) {
-      rpc.executions.delete(execId)
-    }
+    activeSession.cleanup()
+    activeSessions.delete(activeSession)
   }
 }
 
 export function dispose(): void {
-  const state = rpcState
-  rpcState = null
-  rpcStatePromise = null
+  for (const session of [...activeSessions]) {
+    session.cleanup()
+    activeSessions.delete(session)
+  }
 
-  if (runtimeInstance) {
-    try {
-      runtimeInstance.dispose()
-    }
-    catch (error) {
-      console.warn('[nuxt-mcp-toolkit] Error disposing runtime:', getErrorMessage(error))
-    }
-    runtimeInstance = null
-  }
-  if (state) {
-    state.executions.clear()
-    try {
-      state.server.close()
-    }
-    catch (error) {
-      console.warn('[nuxt-mcp-toolkit] Error closing RPC server during dispose:', getErrorMessage(error))
-    }
-  }
   secureExecModule = null
   cachedProxyKey = ''
   cachedProxyCode = ''

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.ts
@@ -1,5 +1,6 @@
-import { createServer, type Server } from 'node:http'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import { randomBytes } from 'node:crypto'
+import { AsyncLocalStorage } from 'node:async_hooks'
 import type { CodeModeOptions, ExecuteResult } from './types'
 import { normalizeCode } from './normalize-code'
 
@@ -10,6 +11,10 @@ type DispatchFn = (args: unknown) => Promise<unknown>
 
 const ERROR_PREFIX = '__ERROR__'
 const DEFAULT_MAX_RESULT_SIZE = 102_400 // 100KB
+const DEFAULT_MAX_REQUEST_BODY_BYTES = 1_048_576 // 1MB
+const DEFAULT_MAX_TOOL_RESPONSE_SIZE = 1_048_576 // 1MB
+const DEFAULT_WALL_TIME_LIMIT_MS = 60_000 // 60s
+const DEFAULT_MAX_TOOL_CALLS = 200
 const MAX_LOG_ENTRIES = 200
 const RETURN_TOOL = '__return__'
 
@@ -22,7 +27,8 @@ async function loadSecureExec() {
     secureExecModule = await import('secure-exec')
     return secureExecModule
   }
-  catch {
+  catch (error) {
+    console.error('[nuxt-mcp-toolkit] Failed to load secure-exec:', error)
     throw new Error(
       '[nuxt-mcp-toolkit] Code Mode requires `secure-exec`. Install it with: npm install secure-exec',
     )
@@ -73,69 +79,219 @@ function createRpcOnlyAdapter(allowedPort: number) {
   }
 }
 
-interface RpcState {
-  server: Server
-  port: number
-  token: string
+interface ExecutionContext {
   fns: Record<string, DispatchFn>
   onReturn?: (value: unknown) => void
+  returned: boolean
+  /**
+   * Function returned by AsyncLocalStorage.snapshot() that re-enters the
+   * async context active when execute() was called, before invoking the
+   * provided callback.
+   */
+  restoreContext: <R, TArgs extends unknown[]>(fn: (...args: TArgs) => R, ...args: TArgs) => R
+  deadlineMs: number
+  rpcCallCount: number
+  maxToolCalls: number
+  maxToolResponseSize: number
+}
+
+interface RpcState {
+  server: Server
+  readonly port: number
+  readonly token: string
+  readonly executions: Map<string, ExecutionContext>
+  readonly maxRequestBodyBytes: number
 }
 
 let rpcState: RpcState | null = null
+let rpcStatePromise: Promise<RpcState> | null = null
 
-function ensureRpcServer(): Promise<RpcState> {
-  if (rpcState) return Promise.resolve(rpcState)
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
 
-  return new Promise((resolve) => {
-    const token = randomBytes(32).toString('hex')
-    const state: RpcState = { server: null!, port: 0, token, fns: {} }
+function sanitizeErrorMessage(msg: string): string {
+  return msg
+    .replace(/(?:\/[\w.][-\w.]*)+\.\w+/g, '[path]')
+    .replace(/(?:[A-Z]:\\[\w.][-\w.\\]*)+/g, '[path]')
+    .replace(/\n\s+at .+/g, '')
+    .slice(0, 500)
+}
 
-    const server = createServer(async (req, res) => {
-      if (req.headers['x-rpc-token'] !== state.token) {
-        res.writeHead(403, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: 'Forbidden' }))
+function sendJson(
+  res: ServerResponse,
+  status: number,
+  payload: Record<string, unknown>,
+): void {
+  let serialized: string
+  try {
+    serialized = JSON.stringify(payload)
+  }
+  catch (error) {
+    console.warn('[nuxt-mcp-toolkit] Failed to serialize RPC response:', getErrorMessage(error))
+    if (res.headersSent) {
+      res.destroy()
+      return
+    }
+    serialized = JSON.stringify({ error: 'Failed to serialize RPC response' })
+    status = 500
+  }
+
+  try {
+    res.writeHead(status, { 'Content-Type': 'application/json' })
+    res.end(serialized)
+  }
+  catch (error) {
+    console.warn('[nuxt-mcp-toolkit] Failed to write RPC response:', getErrorMessage(error))
+    if (res.headersSent) {
+      res.destroy()
+      return
+    }
+
+    try {
+      res.writeHead(500, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Failed to send RPC response' }))
+    }
+    catch (innerError) {
+      console.warn('[nuxt-mcp-toolkit] RPC response write failed, destroying socket:', getErrorMessage(innerError))
+      res.destroy()
+    }
+  }
+}
+
+async function handleRpcRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  state: Pick<RpcState, 'token' | 'executions' | 'maxRequestBodyBytes'>,
+): Promise<void> {
+  if (req.headers['x-rpc-token'] !== state.token) {
+    sendJson(res, 403, { error: 'Forbidden' })
+    return
+  }
+
+  try {
+    let body = ''
+    let byteCount = 0
+    for await (const chunk of req) {
+      const str = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString()
+      byteCount += Buffer.byteLength(str)
+      if (byteCount > state.maxRequestBodyBytes) {
+        sendJson(res, 413, { error: 'Request body exceeds size limit' })
+        return
+      }
+      body += str
+    }
+
+    const { tool: name, args, execId } = JSON.parse(body) as {
+      tool: string
+      args: unknown
+      execId: string
+    }
+
+    if (typeof execId !== 'string' || execId.length === 0) {
+      sendJson(res, 400, { error: 'Missing execution id' })
+      return
+    }
+
+    const exec = state.executions.get(execId)
+    if (!exec) {
+      sendJson(res, 400, { error: `Unknown execution: ${execId}` })
+      return
+    }
+
+    if (Date.now() > exec.deadlineMs) {
+      sendJson(res, 408, { error: 'Execution wall-clock timeout exceeded' })
+      return
+    }
+
+    if (name === RETURN_TOOL) {
+      if (!exec.onReturn) {
+        sendJson(res, 400, { error: `Execution cannot accept return value: ${execId}` })
+        return
+      }
+      if (exec.returned) {
+        sendJson(res, 400, { error: 'Return value already received for this execution' })
         return
       }
 
-      let body = ''
-      for await (const chunk of req) body += chunk
+      exec.restoreContext(exec.onReturn, args)
+      exec.returned = true
+      sendJson(res, 200, { result: { ok: true } })
+      return
+    }
 
-      try {
-        const { tool: name, args } = JSON.parse(body) as { tool: string, args: unknown }
+    const fn = exec.fns[name]
+    if (!fn) {
+      sendJson(res, 400, { error: `Unknown tool: ${name}` })
+      return
+    }
 
-        if (name === RETURN_TOOL && state.onReturn) {
-          state.onReturn(args)
-          res.writeHead(200, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ result: { ok: true } }))
-          return
+    exec.rpcCallCount++
+    if (exec.rpcCallCount > exec.maxToolCalls) {
+      sendJson(res, 429, { error: `Tool call limit exceeded (max ${exec.maxToolCalls})` })
+      return
+    }
+
+    const result = await exec.restoreContext(fn, args)
+    const serialized = JSON.stringify(result)
+    if (serialized.length > exec.maxToolResponseSize) {
+      sendJson(res, 200, { result: truncateResult(result, serialized.length, exec.maxToolResponseSize) })
+    }
+    else {
+      sendJson(res, 200, { result })
+    }
+  }
+  catch (error) {
+    console.error('[nuxt-mcp-toolkit] RPC dispatch error:', error)
+    sendJson(res, 500, { error: sanitizeErrorMessage(getErrorMessage(error)) })
+  }
+}
+
+function ensureRpcServer(maxRequestBodyBytes: number): Promise<RpcState> {
+  if (rpcState) return Promise.resolve(rpcState)
+  if (rpcStatePromise) return rpcStatePromise
+
+  rpcStatePromise = new Promise((resolve, reject) => {
+    const token = randomBytes(32).toString('hex')
+    const executions = new Map<string, ExecutionContext>()
+    const stateRef = { token, executions, maxRequestBodyBytes }
+    const server = createServer((req, res) => {
+      handleRpcRequest(req, res, stateRef).catch((error) => {
+        console.error('[nuxt-mcp-toolkit] Unhandled RPC error:', error)
+        if (!res.headersSent) {
+          try {
+            sendJson(res, 500, { error: 'Internal server error' })
+          }
+          catch {
+            res.destroy()
+          }
         }
-
-        const fn = state.fns[name]
-        if (!fn) {
-          res.writeHead(400, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ error: `Unknown tool: ${name}` }))
-          return
-        }
-        const result = await fn(args)
-        res.writeHead(200, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ result }))
-      }
-      catch (err) {
-        res.writeHead(500, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({
-          error: err instanceof Error ? err.message : String(err),
-        }))
-      }
+      })
     })
 
+    const onError = (error: Error) => {
+      rpcStatePromise = null
+      console.error('[nuxt-mcp-toolkit] RPC server startup failed:', error)
+      try {
+        server.close()
+      }
+      catch (closeError) {
+        console.warn('[nuxt-mcp-toolkit] Failed to close RPC server during error cleanup:', getErrorMessage(closeError))
+      }
+      reject(error)
+    }
+
+    server.once('error', onError)
     server.listen(0, '127.0.0.1', () => {
       const addr = server.address() as { port: number }
-      state.server = server
-      state.port = addr.port
+      server.off('error', onError)
+      const state: RpcState = { server, port: addr.port, token, executions, maxRequestBodyBytes }
       rpcState = state
       resolve(state)
     })
   })
+
+  return rpcStatePromise
 }
 
 let cachedProxyKey = ''
@@ -162,7 +318,7 @@ async function rpc(toolName, args) {
   const res = await fetch('http://127.0.0.1:${port}', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'x-rpc-token': '${token}' },
-    body: JSON.stringify({ tool: toolName, args }),
+    body: JSON.stringify({ tool: toolName, args, execId: __execId }),
   });
   const data = JSON.parse(typeof res.text === 'function' ? await res.text() : res.body);
   if (data.error) throw new Error(data.error);
@@ -181,11 +337,13 @@ function buildSandboxCode(
   toolNames: string[],
   port: number,
   token: string,
+  execId: string,
 ): string {
   const boilerplate = getProxyBoilerplate(toolNames, port, token)
   const cleaned = normalizeCode(userCode)
 
-  return `${boilerplate}
+  return `const __execId = ${JSON.stringify(execId)};
+${boilerplate}
 
 const __fn = async () => {
 ${cleaned}
@@ -241,87 +399,135 @@ export async function execute(
   fns: Record<string, DispatchFn>,
   options?: CodeModeOptions,
 ): Promise<ExecuteResult> {
-  const secureExec = await loadSecureExec()
-
-  const rpc = await ensureRpcServer()
-  rpc.fns = fns
-
-  const toolNames = Object.keys(fns)
-  const sandboxCode = buildSandboxCode(code, toolNames, rpc.port, rpc.token)
-
-  // Result delivered via RPC — avoids console.log buffer limits (~4KB)
-  let returnedResult: { value: unknown, received: boolean } = { value: undefined, received: false }
-  rpc.onReturn = (value: unknown) => {
-    returnedResult = { value, received: true }
-  }
-
-  // Runtime is a singleton — memoryLimit and cpuTimeLimitMs are locked
-  // from the first call. Call dispose() and re-execute to change them.
-  if (!runtimeInstance) {
-    runtimeInstance = new secureExec.NodeRuntime({
-      systemDriver: secureExec.createNodeDriver({
-        networkAdapter: createRpcOnlyAdapter(rpc.port),
-        permissions: {
-          network: () => ({ allow: true }),
-        },
-      }),
-      runtimeDriverFactory: secureExec.createNodeRuntimeDriverFactory(),
-      memoryLimit: options?.memoryLimit ?? 64,
-      cpuTimeLimitMs: options?.cpuTimeLimitMs ?? 10_000,
-    })
-  }
-
-  let errorMsg: string | undefined
   const logs: string[] = []
 
-  const execResult = await runtimeInstance.exec(sandboxCode, {
-    onStdio: ({ channel, message }: { channel: string, message: string }) => {
-      if (channel === 'stderr' && message.startsWith(ERROR_PREFIX)) {
-        errorMsg = message.slice(ERROR_PREFIX.length)
-      }
-      else if (logs.length < MAX_LOG_ENTRIES) {
-        logs.push(`[${channel}] ${message}`)
-      }
-      else if (logs.length === MAX_LOG_ENTRIES) {
-        logs.push(`... log output truncated at ${MAX_LOG_ENTRIES} entries`)
-      }
-    },
-  })
-
-  rpc.onReturn = undefined
-
-  if (execResult.code !== 0 || errorMsg) {
+  if (typeof AsyncLocalStorage.snapshot !== 'function') {
     return {
       result: undefined,
-      error: errorMsg ?? execResult.errorMessage ?? `Exit code ${execResult.code}`,
+      error: '[nuxt-mcp-toolkit] Code Mode requires Node.js >=18.16.0 (AsyncLocalStorage.snapshot is unavailable).',
       logs,
     }
   }
 
-  let result: unknown
-  if (returnedResult.received) {
-    const maxSize = options?.maxResultSize ?? DEFAULT_MAX_RESULT_SIZE
-    const serialized = JSON.stringify(returnedResult.value)
+  let rpc: RpcState | undefined
+  let execId: string | undefined
+  let returnedResult: { value: unknown, received: boolean } = { value: undefined, received: false }
 
-    if (serialized.length <= maxSize) {
-      result = returnedResult.value
+  try {
+    const secureExec = await loadSecureExec()
+    rpc = await ensureRpcServer(options?.maxRequestBodyBytes ?? DEFAULT_MAX_REQUEST_BODY_BYTES)
+
+    execId = randomBytes(8).toString('hex')
+    const restoreContext = AsyncLocalStorage.snapshot()
+
+    // Result delivered via RPC per execution, avoiding console.log buffer limits (~4KB)
+    rpc.executions.set(execId, {
+      fns: Object.freeze({ ...fns }),
+      onReturn: (value: unknown) => {
+        returnedResult = { value, received: true }
+      },
+      returned: false,
+      restoreContext,
+      deadlineMs: Date.now() + (options?.wallTimeLimitMs ?? DEFAULT_WALL_TIME_LIMIT_MS),
+      rpcCallCount: 0,
+      maxToolCalls: options?.maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS,
+      maxToolResponseSize: options?.maxToolResponseSize ?? DEFAULT_MAX_TOOL_RESPONSE_SIZE,
+    })
+
+    const toolNames = Object.keys(fns)
+    const sandboxCode = buildSandboxCode(code, toolNames, rpc.port, rpc.token, execId)
+
+    // Runtime is a singleton — memoryLimit and cpuTimeLimitMs are locked
+    // from the first call. Call dispose() and re-execute to change them.
+    if (!runtimeInstance) {
+      runtimeInstance = new secureExec.NodeRuntime({
+        systemDriver: secureExec.createNodeDriver({
+          networkAdapter: createRpcOnlyAdapter(rpc.port),
+          permissions: {
+            network: () => ({ allow: true }),
+          },
+        }),
+        runtimeDriverFactory: secureExec.createNodeRuntimeDriverFactory(),
+        memoryLimit: options?.memoryLimit ?? 64,
+        cpuTimeLimitMs: options?.cpuTimeLimitMs ?? 10_000,
+      })
     }
-    else {
-      result = truncateResult(returnedResult.value, serialized.length, maxSize)
+
+    let errorMsg: string | undefined
+    const execResult = await runtimeInstance.exec(sandboxCode, {
+      onStdio: ({ channel, message }: { channel: string, message: string }) => {
+        if (channel === 'stderr' && message.startsWith(ERROR_PREFIX)) {
+          errorMsg = message.slice(ERROR_PREFIX.length)
+        }
+        else if (logs.length < MAX_LOG_ENTRIES) {
+          logs.push(`[${channel}] ${message}`)
+        }
+        else if (logs.length === MAX_LOG_ENTRIES) {
+          logs.push(`... log output truncated at ${MAX_LOG_ENTRIES} entries`)
+        }
+      },
+    })
+
+    if (execResult.code !== 0 || errorMsg) {
+      return {
+        result: undefined,
+        error: errorMsg ?? execResult.errorMessage ?? `Exit code ${execResult.code}`,
+        logs,
+      }
+    }
+
+    let result: unknown
+    if (returnedResult.received) {
+      const maxSize = options?.maxResultSize ?? DEFAULT_MAX_RESULT_SIZE
+      const serialized = JSON.stringify(returnedResult.value)
+
+      if (serialized.length <= maxSize) {
+        result = returnedResult.value
+      }
+      else {
+        result = truncateResult(returnedResult.value, serialized.length, maxSize)
+      }
+    }
+
+    return { result, logs }
+  }
+  catch (error) {
+    console.error('[nuxt-mcp-toolkit] Execution error:', error)
+    return {
+      result: undefined,
+      error: sanitizeErrorMessage(getErrorMessage(error)),
+      logs,
     }
   }
-
-  return { result, logs }
+  finally {
+    if (rpc && execId) {
+      rpc.executions.delete(execId)
+    }
+  }
 }
 
 export function dispose(): void {
+  const state = rpcState
+  rpcState = null
+  rpcStatePromise = null
+
   if (runtimeInstance) {
-    runtimeInstance.dispose()
+    try {
+      runtimeInstance.dispose()
+    }
+    catch (error) {
+      console.warn('[nuxt-mcp-toolkit] Error disposing runtime:', getErrorMessage(error))
+    }
     runtimeInstance = null
   }
-  if (rpcState) {
-    rpcState.server.close()
-    rpcState = null
+  if (state) {
+    state.executions.clear()
+    try {
+      state.server.close()
+    }
+    catch (error) {
+      console.warn('[nuxt-mcp-toolkit] Error closing RPC server during dispose:', getErrorMessage(error))
+    }
   }
   secureExecModule = null
   cachedProxyKey = ''

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.ts
@@ -322,6 +322,13 @@ async function rpc(toolName, args) {
   });
   const data = JSON.parse(typeof res.text === 'function' ? await res.text() : res.body);
   if (data.error) throw new Error(data.error);
+  if (data.result && data.result.__toolError) {
+    const err = new Error(data.result.message);
+    err.tool = data.result.tool;
+    err.isToolError = true;
+    err.details = data.result.details;
+    throw err;
+  }
   return data.result;
 }
 

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/executor.ts
@@ -48,6 +48,7 @@ interface ActiveSession {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let secureExecModule: any = null
 const activeSessions = new Set<ActiveSession>()
+let snapshotWarnLogged = false
 
 async function loadSecureExec() {
   if (secureExecModule) return secureExecModule
@@ -376,16 +377,18 @@ export async function execute(
   const startedAt = Date.now()
   const logs: string[] = []
 
-  if (typeof AsyncLocalStorage.snapshot !== 'function') {
-    return {
-      result: undefined,
-      error: '[nuxt-mcp-toolkit] Code Mode requires Node.js >=18.16.0 (AsyncLocalStorage.snapshot is unavailable).',
-      logs,
-      durationMs: Date.now() - startedAt,
-    }
-  }
-
-  const restoreContext = AsyncLocalStorage.snapshot()
+  const restoreContext = typeof AsyncLocalStorage.snapshot === 'function'
+    ? AsyncLocalStorage.snapshot()
+    : (() => {
+        if (!snapshotWarnLogged) {
+          snapshotWarnLogged = true
+          console.warn(
+            '[nuxt-mcp-toolkit] AsyncLocalStorage.snapshot unavailable (Node.js <18.16.0). '
+            + 'Tool handlers in code mode will not have access to request context (useEvent, auth, etc.).',
+          )
+        }
+        return <R, TArgs extends unknown[]>(fn: (...args: TArgs) => R, ...args: TArgs) => fn(...args)
+      })()
   let returnedResult: { received: boolean, value: unknown } = { received: false, value: undefined }
   let rpcSession: RpcSession | null = null
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
@@ -23,69 +23,54 @@ async function runExecute(
   return execute(code, fns, options)
 }
 
-const CODE_TOOL_DESCRIPTION_TEMPLATE = `Execute JavaScript to orchestrate multiple tool calls in a SINGLE invocation. ALWAYS combine ALL related operations into one code block — never split into separate calls.
+const CODE_TOOL_DESCRIPTION_TEMPLATE = `Execute JavaScript to orchestrate tool calls in one invocation.
 
-Write the body of an async function. Use \`return\` to return the final result.
+Write the body of an async function and use \`return\` for the final value.
 
-Available tools via the \`codemode\` object:
+Available via the \`codemode\` object:
 \`\`\`typescript
 {{types}}
-\`\`\`
+\`\`\`{{example}}`
 
-IMPORTANT: Combine sequential, parallel, and conditional logic in ONE code block:
+const PROGRESSIVE_CODE_DESCRIPTION_TEMPLATE = `Execute JavaScript to orchestrate tool calls in one invocation.
+
+Write the body of an async function and use \`return\` for the final value.
+
+{{count}} tools are available via the \`codemode\` object. Use the \`search\` tool to find names and signatures before writing code.{{example}}`
+
+const STANDARD_CODE_EXAMPLE = `
+
+Example:
 \`\`\`javascript
-// Sequential: chain dependent calls
 const data = await codemode.get_data({ id: "123" });
 const result = await codemode.process({ input: data.value });
-
-// Parallel: use Promise.all for independent calls
-const [a, b, c] = await Promise.all([
-  codemode.task({ name: "a" }),
-  codemode.task({ name: "b" }),
-  codemode.task({ name: "c" }),
-]);
-
-// Conditional + loops
-for (const item of items) {
-  if (item.active) await codemode.handle({ id: item.id });
-}
-
 return result;
 \`\`\``
 
-const PROGRESSIVE_CODE_DESCRIPTION_TEMPLATE = `Execute JavaScript to orchestrate tool calls in a SINGLE invocation. ALWAYS combine ALL related operations into one code block.
+const PROGRESSIVE_CODE_EXAMPLE = `
 
-Write the body of an async function. Use \`return\` to return the final result.
-
-{{count}} tools available via the \`codemode\` object. Use the \`search\` tool first to discover tool names and type signatures, then write code using \`codemode.toolName(input)\`.
-
-IMPORTANT: Combine sequential, parallel, and conditional logic in ONE code block:
+Example:
 \`\`\`javascript
-// Sequential
-const data = await codemode.get_data({ id: "123" });
-const result = await codemode.process({ input: data.value });
-
-// Parallel
-const [a, b] = await Promise.all([
-  codemode.task_a(),
-  codemode.task_b(),
-]);
-
-return result;
+// After using the search tool to find the right method names:
+const user = await codemode.get_user({ id: "123" });
+return user;
 \`\`\``
 
 const SEARCH_TOOL_DESCRIPTION = `Search available tools by keyword. Returns tool names, descriptions, and type signatures you can use with the \`code\` tool.
 
 Use this to discover which \`codemode.*\` methods are available before writing code.`
 
+const MAX_TOOLS_WITH_EXAMPLE_BLOCK = 10
+
 function applyDescriptionTemplate(
   template: string,
-  vars: { types?: string, count?: number },
+  vars: { types?: string, count?: number, example?: string },
 ): string {
   let result = template
   if (vars.types !== undefined) result = result.replace('{{types}}', vars.types)
   if (vars.count !== undefined) result = result.replaceAll('{{count}}', String(vars.count))
-  return result
+  result = result.replace('{{example}}', vars.example ?? '')
+  return result.replace(/\n{3,}/g, '\n\n').trim()
 }
 
 /**
@@ -115,6 +100,7 @@ function createStandardTools(
   const description = applyDescriptionTemplate(template, {
     types: typeDefinitions,
     count: tools.length,
+    example: tools.length > MAX_TOOLS_WITH_EXAMPLE_BLOCK ? '' : STANDARD_CODE_EXAMPLE,
   })
 
   const fns = buildDispatchFunctions(tools, toolNameMap)
@@ -131,7 +117,10 @@ function createProgressiveTools(
   const { entries, toolNameMap } = generateToolCatalog(tools)
 
   const template = options?.description || PROGRESSIVE_CODE_DESCRIPTION_TEMPLATE
-  const description = applyDescriptionTemplate(template, { count: tools.length })
+  const description = applyDescriptionTemplate(template, {
+    count: tools.length,
+    example: tools.length > MAX_TOOLS_WITH_EXAMPLE_BLOCK ? '' : PROGRESSIVE_CODE_EXAMPLE,
+  })
 
   const fns = buildDispatchFunctions(tools, toolNameMap)
   const toolNames = [...toolNameMap.keys()]

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
@@ -72,7 +72,7 @@ Write the body of an async function and use \`return\` for the final value.
 
 {{count}} tools are available via the \`codemode\` object. Use the \`search\` tool to find names and signatures before writing code.{{example}}`
 
-const STANDARD_CODE_EXAMPLE = `
+const STANDARD_CODE_EXAMPLE_FALLBACK = `
 
 Example:
 \`\`\`javascript
@@ -81,7 +81,7 @@ const result = await codemode.process({ input: data.value });
 return result;
 \`\`\``
 
-const PROGRESSIVE_CODE_EXAMPLE = `
+const PROGRESSIVE_CODE_EXAMPLE_FALLBACK = `
 
 Example:
 \`\`\`javascript
@@ -124,11 +124,15 @@ function createStandardTools(
   const { typeDefinitions, toolNameMap } = generateTypesFromTools(tools)
   const dispatchEntries = buildDispatchEntries(tools, toolNameMap)
 
+  const example = tools.length > MAX_TOOLS_WITH_EXAMPLE_BLOCK
+    ? ''
+    : STANDARD_CODE_EXAMPLE_FALLBACK
+
   const template = options?.description || CODE_TOOL_DESCRIPTION_TEMPLATE
   const description = applyDescriptionTemplate(template, {
     types: typeDefinitions,
     count: tools.length,
-    example: tools.length > MAX_TOOLS_WITH_EXAMPLE_BLOCK ? '' : STANDARD_CODE_EXAMPLE,
+    example,
   })
 
   const codeTool = buildCodeTool(description, dispatchEntries, options)
@@ -142,10 +146,14 @@ function createProgressiveTools(
   const { entries, toolNameMap } = generateToolCatalog(tools)
   const dispatchEntries = buildDispatchEntries(tools, toolNameMap)
 
+  const example = tools.length > MAX_TOOLS_WITH_EXAMPLE_BLOCK
+    ? ''
+    : PROGRESSIVE_CODE_EXAMPLE_FALLBACK
+
   const template = options?.description || PROGRESSIVE_CODE_DESCRIPTION_TEMPLATE
   const description = applyDescriptionTemplate(template, {
     count: tools.length,
-    example: tools.length > MAX_TOOLS_WITH_EXAMPLE_BLOCK ? '' : PROGRESSIVE_CODE_EXAMPLE,
+    example,
   })
 
   const searchTool = buildSearchTool(entries)

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
@@ -29,9 +29,9 @@ interface CodeModeToolError {
   details?: unknown
 }
 
-type CodeToolEnvelope =
-  | { ok: true, result?: unknown, error?: undefined, logs?: string[], durationMs: number }
-  | { ok: false, result?: undefined, error: string, logs?: string[], durationMs: number }
+type CodeToolEnvelope
+  = | { ok: true, result?: unknown, error?: undefined, logs?: string[], durationMs: number }
+    | { ok: false, result?: undefined, error: string, logs?: string[], durationMs: number }
 
 interface DispatchToolEntry {
   originalName: string

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
@@ -264,6 +264,21 @@ function buildDispatchFunctions(
       // Normalize string/number returns before code mode consumes them
       const result = normalizeToolResult(rawResult as Parameters<typeof normalizeToolResult>[0])
 
+      // Surface tool errors as a sentinel so the sandbox can throw
+      if (result.isError) {
+        const errorText = result.content
+          ?.filter((c): c is { type: 'text', text: string } => c.type === 'text')
+          .map(c => c.text)
+          .join('\n') ?? 'Tool execution failed'
+
+        return {
+          __toolError: true,
+          message: errorText,
+          tool: sanitized,
+          details: result.structuredContent ?? undefined,
+        }
+      }
+
       // Prefer structuredContent when available (preserves typed data)
       if (result.structuredContent != null) {
         return result.structuredContent
@@ -289,6 +304,11 @@ function buildDispatchFunctions(
 
   return fns
 }
+
+/**
+ * @internal
+ */
+export { buildDispatchFunctions }
 
 /**
  * Check if a tool name needs sanitization for JavaScript

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
@@ -23,19 +23,15 @@ import {
 export type { CodeModeOptions }
 
 interface CodeModeToolError {
-  __toolError: true
+  __mcp_toolkit_error__: true
   message: string
   tool: string
   details?: unknown
 }
 
-interface CodeToolEnvelope {
-  ok: boolean
-  result?: unknown
-  error?: string
-  logs?: string[]
-  durationMs: number
-}
+type CodeToolEnvelope =
+  | { ok: true, result?: unknown, error?: undefined, logs?: string[], durationMs: number }
+  | { ok: false, result?: undefined, error: string, logs?: string[], durationMs: number }
 
 interface DispatchToolEntry {
   originalName: string
@@ -280,7 +276,7 @@ function extractTextContent(result: { content?: Array<{ type: string, text?: str
 
 function toToolError(result: { content?: Array<{ type: string, text?: string }>, structuredContent?: unknown }, tool: string): CodeModeToolError {
   return {
-    __toolError: true,
+    __mcp_toolkit_error__: true,
     message: extractTextContent(result)
       ?? (result.structuredContent !== undefined ? JSON.stringify(result.structuredContent) : 'Tool execution failed'),
     tool,
@@ -325,21 +321,16 @@ function normalizeDispatchResult(rawResult: unknown, tool: string): unknown {
 }
 
 function createCodeToolEnvelope(result: ExecuteResult): CodeToolEnvelope {
-  const envelope: CodeToolEnvelope = {
-    ok: !result.error,
-    durationMs: result.durationMs,
+  const logs = result.logs.length > 0 ? result.logs : undefined
+
+  if (result.error) {
+    return { ok: false, error: result.error, logs, durationMs: result.durationMs }
   }
 
+  const envelope: CodeToolEnvelope = { ok: true, durationMs: result.durationMs, logs }
   if (result.result !== undefined) {
     envelope.result = result.result
   }
-  if (result.error) {
-    envelope.error = result.error
-  }
-  if (result.logs.length > 0) {
-    envelope.logs = result.logs
-  }
-
   return envelope
 }
 
@@ -394,5 +385,5 @@ export { sanitizeToolName }
 export function disposeCodeMode(): void {
   void import('./executor')
     .then(m => m.dispose())
-    .catch(() => {})
+    .catch(error => console.warn('[nuxt-mcp-toolkit] disposeCodeMode failed:', error))
 }

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
@@ -1,18 +1,56 @@
 import { z } from 'zod'
-import type { McpToolDefinition, McpToolDefinitionListItem } from '../definitions/tools'
-import { normalizeToolResult } from '../definitions/results'
-import { enrichNameTitle } from '../definitions/utils'
+import type { McpRequestExtra } from '../definitions/sdk-extra'
 import {
-  generateTypesFromTools,
-  generateToolCatalog,
-  searchToolCatalog,
+  type McpToolDefinition,
+  type McpToolDefinitionListItem,
+  createWrappedToolHandler,
+  invokeWrappedToolHandler,
+  normalizeErrorToResult,
+  resolveToolDefinitionName,
+} from '../definitions/tools'
+import { isCallToolResult } from '../definitions/results'
+import {
   formatSearchResults,
+  generateToolCatalog,
+  generateTypesFromTools,
   sanitizeToolName,
-  type ToolCatalogEntry,
+  searchToolCatalog,
   type CodeModeOptions,
+  type ExecuteResult,
+  type ToolCatalogEntry,
 } from './types'
 
 export type { CodeModeOptions }
+
+interface CodeModeToolError {
+  __toolError: true
+  message: string
+  tool: string
+  details?: unknown
+}
+
+interface CodeToolEnvelope {
+  ok: boolean
+  result?: unknown
+  error?: string
+  logs?: string[]
+  durationMs: number
+}
+
+interface DispatchToolEntry {
+  originalName: string
+  sanitizedName: string
+  tool: McpToolDefinitionListItem
+  handler: (...args: unknown[]) => unknown
+}
+
+const CODE_TOOL_OUTPUT_SCHEMA = {
+  ok: z.boolean(),
+  result: z.unknown().optional(),
+  error: z.string().optional(),
+  logs: z.array(z.string()).optional(),
+  durationMs: z.number(),
+}
 
 async function runExecute(
   code: string,
@@ -73,13 +111,6 @@ function applyDescriptionTemplate(
   return result.replace(/\n{3,}/g, '\n\n').trim()
 }
 
-/**
- * Wraps an array of tool definitions into code mode tools.
- *
- * Standard mode: single `code` tool with all type definitions embedded.
- * Progressive mode (`progressive: true`): `search` + `code` tools — the LLM
- * discovers tool signatures via search, keeping the code tool lightweight.
- */
 export function createCodemodeTools(
   tools: McpToolDefinitionListItem[],
   options?: CodeModeOptions,
@@ -95,6 +126,7 @@ function createStandardTools(
   options?: CodeModeOptions,
 ): McpToolDefinitionListItem[] {
   const { typeDefinitions, toolNameMap } = generateTypesFromTools(tools)
+  const dispatchEntries = buildDispatchEntries(tools, toolNameMap)
 
   const template = options?.description || CODE_TOOL_DESCRIPTION_TEMPLATE
   const description = applyDescriptionTemplate(template, {
@@ -103,10 +135,7 @@ function createStandardTools(
     example: tools.length > MAX_TOOLS_WITH_EXAMPLE_BLOCK ? '' : STANDARD_CODE_EXAMPLE,
   })
 
-  const fns = buildDispatchFunctions(tools, toolNameMap)
-  const toolNames = [...toolNameMap.keys()]
-
-  const codeTool = buildCodeTool(description, fns, toolNames, options)
+  const codeTool = buildCodeTool(description, dispatchEntries, options)
   return [codeTool as McpToolDefinitionListItem]
 }
 
@@ -115,6 +144,7 @@ function createProgressiveTools(
   options?: CodeModeOptions,
 ): McpToolDefinitionListItem[] {
   const { entries, toolNameMap } = generateToolCatalog(tools)
+  const dispatchEntries = buildDispatchEntries(tools, toolNameMap)
 
   const template = options?.description || PROGRESSIVE_CODE_DESCRIPTION_TEMPLATE
   const description = applyDescriptionTemplate(template, {
@@ -122,11 +152,8 @@ function createProgressiveTools(
     example: tools.length > MAX_TOOLS_WITH_EXAMPLE_BLOCK ? '' : PROGRESSIVE_CODE_EXAMPLE,
   })
 
-  const fns = buildDispatchFunctions(tools, toolNameMap)
-  const toolNames = [...toolNameMap.keys()]
-
   const searchTool = buildSearchTool(entries)
-  const codeTool = buildCodeTool(description, fns, toolNames, options)
+  const codeTool = buildCodeTool(description, dispatchEntries, options)
 
   return [searchTool as McpToolDefinitionListItem, codeTool as McpToolDefinitionListItem]
 }
@@ -156,14 +183,16 @@ function buildSearchTool(
 
 function buildCodeTool(
   description: string,
-  fns: Record<string, (args: unknown) => Promise<unknown>>,
-  toolNames: string[],
+  dispatchEntries: DispatchToolEntry[],
   options?: CodeModeOptions,
-): McpToolDefinition<{ code: z.ZodString }> {
+): McpToolDefinition<{ code: z.ZodString }, typeof CODE_TOOL_OUTPUT_SCHEMA> {
+  const toolNames = dispatchEntries.map(entry => entry.sanitizedName)
+
   return {
     name: 'code',
     title: 'Code Mode',
     description,
+    outputSchema: CODE_TOOL_OUTPUT_SCHEMA,
     annotations: {
       readOnlyHint: false,
       destructiveHint: true,
@@ -172,45 +201,174 @@ function buildCodeTool(
     inputSchema: {
       code: z.string().describe('JavaScript code to execute. Write the body of an async function.'),
     },
-    handler: async ({ code }) => {
-      const result = await runExecute(code, fns, options)
-      const logSuffix = formatLogs(result.logs)
-
-      if (result.error) {
-        return {
-          isError: true,
-          content: [{ type: 'text' as const, text: formatError(result.error, code, toolNames, logSuffix) }],
-        }
-      }
-
-      let resultText: string
-      if (result.result === undefined || result.result === null) {
-        resultText = 'No return value.'
-      }
-      else if (typeof result.result === 'string') {
-        resultText = result.result
-      }
-      else {
-        try {
-          resultText = JSON.stringify(result.result)
-        }
-        catch {
-          resultText = String(result.result)
-        }
-      }
+    handler: async ({ code }, extra) => {
+      const fns = buildDispatchFunctionsFromEntries(dispatchEntries, extra)
+      const executeResult = await runExecute(code, fns, options)
+      const envelope = createCodeToolEnvelope(executeResult)
 
       return {
-        content: [{ type: 'text' as const, text: `${resultText}${logSuffix}` }],
+        isError: !envelope.ok,
+        structuredContent: envelope,
+        content: [{
+          type: 'text' as const,
+          text: envelope.ok
+            ? formatSuccessContent(envelope)
+            : formatError(envelope.error ?? 'Execution failed', code, toolNames, envelope.logs ?? []),
+        }],
       }
     },
   }
+}
+
+function buildDispatchEntries(
+  tools: McpToolDefinitionListItem[],
+  toolNameMap: Map<string, string>,
+): DispatchToolEntry[] {
+  const toolsByName = new Map<string, McpToolDefinitionListItem>()
+  for (const tool of tools) {
+    toolsByName.set(resolveToolDefinitionName(tool), tool)
+  }
+
+  const entries: DispatchToolEntry[] = []
+  for (const [sanitizedName, originalName] of toolNameMap) {
+    const tool = toolsByName.get(originalName)
+    if (!tool) continue
+
+    entries.push({
+      originalName,
+      sanitizedName,
+      tool,
+      handler: createWrappedToolHandler(tool),
+    })
+  }
+
+  return entries
+}
+
+function buildDispatchFunctionsFromEntries(
+  entries: DispatchToolEntry[],
+  extra: McpRequestExtra,
+): Record<string, (args: unknown) => Promise<unknown>> {
+  const fns: Record<string, (args: unknown) => Promise<unknown>> = {}
+
+  for (const entry of entries) {
+    fns[entry.sanitizedName] = async (input: unknown) => {
+      let rawResult: unknown
+
+      try {
+        rawResult = await invokeWrappedToolHandler(entry.tool, entry.handler, input, extra)
+      }
+      catch (error) {
+        rawResult = normalizeErrorToResult(error)
+      }
+
+      return normalizeDispatchResult(rawResult, entry.sanitizedName)
+    }
+  }
+
+  return fns
+}
+
+function extractTextContent(result: { content?: Array<{ type: string, text?: string }> }): string | undefined {
+  const textContent = result.content
+    ?.filter((item): item is { type: 'text', text: string } => item.type === 'text' && typeof item.text === 'string')
+    .map(item => item.text)
+    .join('\n')
+
+  return textContent && textContent.length > 0 ? textContent : undefined
+}
+
+function toToolError(result: { content?: Array<{ type: string, text?: string }>, structuredContent?: unknown }, tool: string): CodeModeToolError {
+  return {
+    __toolError: true,
+    message: extractTextContent(result)
+      ?? (result.structuredContent !== undefined ? JSON.stringify(result.structuredContent) : 'Tool execution failed'),
+    tool,
+    details: result.structuredContent,
+  }
+}
+
+function normalizeDispatchResult(rawResult: unknown, tool: string): unknown {
+  if (rawResult == null) {
+    return rawResult
+  }
+
+  if (
+    typeof rawResult === 'string'
+    || typeof rawResult === 'number'
+    || typeof rawResult === 'boolean'
+    || Array.isArray(rawResult)
+  ) {
+    return rawResult
+  }
+
+  if (typeof rawResult === 'object') {
+    if (!isCallToolResult(rawResult)) {
+      return rawResult
+    }
+
+    if (rawResult.isError) {
+      return toToolError(rawResult, tool)
+    }
+
+    if (rawResult.structuredContent != null) {
+      return rawResult.structuredContent
+    }
+
+    const textContent = extractTextContent(rawResult)
+    if (textContent !== undefined) {
+      return textContent
+    }
+  }
+
+  return rawResult
+}
+
+function createCodeToolEnvelope(result: ExecuteResult): CodeToolEnvelope {
+  const envelope: CodeToolEnvelope = {
+    ok: !result.error,
+    durationMs: result.durationMs,
+  }
+
+  if (result.result !== undefined) {
+    envelope.result = result.result
+  }
+  if (result.error) {
+    envelope.error = result.error
+  }
+  if (result.logs.length > 0) {
+    envelope.logs = result.logs
+  }
+
+  return envelope
+}
+
+function formatSuccessContent(envelope: CodeToolEnvelope): string {
+  let resultText = 'No return value.'
+
+  if (envelope.result !== undefined && envelope.result !== null) {
+    if (typeof envelope.result === 'string') {
+      resultText = envelope.result
+    }
+    else {
+      try {
+        resultText = JSON.stringify(envelope.result)
+      }
+      catch {
+        resultText = String(envelope.result)
+      }
+    }
+  }
+
+  const logSuffix = formatLogs(envelope.logs ?? [])
+  return `${resultText}${logSuffix}`
 }
 
 function formatLogs(logs: string[]): string {
   return logs.length > 0 ? `\n\nConsole output:\n${logs.join('\n')}` : ''
 }
 
-function formatError(error: string, code: string, toolNames: string[], logOutput: string): string {
+function formatError(error: string, code: string, toolNames: string[], logs: string[]): string {
   const codePreview = code.length > 500 ? `${code.slice(0, 500)}...` : code
   return `Execution error: ${error}
 
@@ -220,94 +378,19 @@ ${codePreview}
 \`\`\`
 
 Available tools: ${toolNames.join(', ')}
-Fix the code and try again in a single combined block.${logOutput}`
+Fix the code and try again in a single combined block.${formatLogs(logs)}`
 }
 
-function buildDispatchFunctions(
+export function buildDispatchFunctions(
   tools: McpToolDefinitionListItem[],
   toolNameMap: Map<string, string>,
+  extra: McpRequestExtra,
 ): Record<string, (args: unknown) => Promise<unknown>> {
-  const fns: Record<string, (args: unknown) => Promise<unknown>> = {}
-
-  const toolsByName = new Map<string, McpToolDefinitionListItem>()
-  for (const tool of tools) {
-    const { name } = enrichNameTitle({
-      name: tool.name,
-      title: tool.title,
-      _meta: tool._meta,
-      type: 'tool',
-    })
-    toolsByName.set(name, tool)
-  }
-
-  for (const [sanitized, original] of toolNameMap) {
-    const tool = toolsByName.get(original)
-    if (!tool) continue
-
-    fns[sanitized] = async (input: unknown) => {
-      const args = input ?? {}
-      const rawResult = tool.inputSchema && Object.keys(tool.inputSchema).length > 0
-        ? await (tool.handler as (args: unknown, extra: unknown) => Promise<unknown>)(args, {})
-        : await (tool.handler as (extra: unknown) => Promise<unknown>)({})
-
-      // Normalize string/number returns before code mode consumes them
-      const result = normalizeToolResult(rawResult as Parameters<typeof normalizeToolResult>[0])
-
-      // Surface tool errors as a sentinel so the sandbox can throw
-      if (result.isError) {
-        const errorText = result.content
-          ?.filter((c): c is { type: 'text', text: string } => c.type === 'text')
-          .map(c => c.text)
-          .join('\n') ?? 'Tool execution failed'
-
-        return {
-          __toolError: true,
-          message: errorText,
-          tool: sanitized,
-          details: result.structuredContent ?? undefined,
-        }
-      }
-
-      // Prefer structuredContent when available (preserves typed data)
-      if (result.structuredContent != null) {
-        return result.structuredContent
-      }
-
-      if (result.content) {
-        const textContent = result.content
-          .filter((c): c is { type: 'text', text: string } => c.type === 'text')
-          .map(c => c.text)
-          .join('\n')
-
-        try {
-          return JSON.parse(textContent)
-        }
-        catch {
-          return textContent
-        }
-      }
-
-      return result
-    }
-  }
-
-  return fns
+  return buildDispatchFunctionsFromEntries(buildDispatchEntries(tools, toolNameMap), extra)
 }
 
-/**
- * @internal
- */
-export { buildDispatchFunctions }
-
-/**
- * Check if a tool name needs sanitization for JavaScript
- */
 export { sanitizeToolName }
 
-/**
- * Dispose the code mode runtime and RPC server.
- * Call this during shutdown to release resources.
- */
 export function disposeCodeMode(): void {
   void import('./executor')
     .then(m => m.dispose())

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/index.ts
@@ -264,6 +264,11 @@ function buildDispatchFunctions(
       // Normalize string/number returns before code mode consumes them
       const result = normalizeToolResult(rawResult as Parameters<typeof normalizeToolResult>[0])
 
+      // Prefer structuredContent when available (preserves typed data)
+      if (result.structuredContent != null) {
+        return result.structuredContent
+      }
+
       if (result.content) {
         const textContent = result.content
           .filter((c): c is { type: 'text', text: string } => c.type === 'text')

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
@@ -105,6 +105,7 @@ interface ToolTypeInfo {
   sanitizedName: string
   typeName: string
   interfaceDecl: string | null
+  outputInterfaceDecl: string | null
   methodSignature: string
 }
 
@@ -155,14 +156,53 @@ function generateToolTypeInfo(tool: McpToolDefinition): ToolTypeInfo {
     }
   }
 
+  // Generate output type from outputSchema
+  let outputInterfaceDecl: string | null = null
+  let returnType = 'unknown'
+  const outputTypeName = `${pascalCase(sanitizedName)}Output`
+
+  if (tool.outputSchema && Object.keys(tool.outputSchema).length > 0) {
+    try {
+      const jsonSchema = z.toJSONSchema(z.object(tool.outputSchema))
+      const properties = jsonSchema.properties as Record<string, Record<string, unknown>> | undefined
+      const required = (jsonSchema.required as string[]) || []
+
+      if (properties && Object.keys(properties).length > 0) {
+        const entries = Object.entries(properties)
+        const allPrimitive = entries.every(([, prop]) => isPrimitiveProp(prop))
+
+        if (entries.length <= INLINE_THRESHOLD && allPrimitive) {
+          const inlineFields = entries.map(([key, prop]) => {
+            const opt = required.includes(key) ? '' : '?'
+            return `${key}${opt}: ${jsonSchemaPropertyToTs(prop)}`
+          })
+          returnType = `{ ${inlineFields.join('; ')} }`
+        }
+        else {
+          const fields = entries.map(([key, prop]) => {
+            const opt = required.includes(key) ? '' : '?'
+            const tsType = jsonSchemaPropertyToTs(prop)
+            return `  ${key}${opt}: ${tsType};`
+          })
+          outputInterfaceDecl = `interface ${outputTypeName} {\n${fields.join('\n')}\n}`
+          returnType = outputTypeName
+        }
+      }
+    }
+    catch {
+      // Fall through to default Promise<unknown>
+    }
+  }
+
   const desc = tool.description ? ` // ${tool.description}` : ''
-  const methodSignature = `${sanitizedName}: (${paramSignature}) => Promise<unknown>;${desc}`
+  const methodSignature = `${sanitizedName}: (${paramSignature}) => Promise<${returnType}>;${desc}`
 
   return {
     originalName: name,
     sanitizedName,
     typeName,
     interfaceDecl,
+    outputInterfaceDecl,
     methodSignature,
   }
 }
@@ -184,7 +224,7 @@ export function generateTypesFromTools(tools: McpToolDefinitionListItem[]): Gene
   const toolInfos = tools.map(generateToolTypeInfo)
 
   const interfaces = toolInfos
-    .map(t => t.interfaceDecl)
+    .flatMap(t => [t.interfaceDecl, t.outputInterfaceDecl])
     .filter(Boolean)
     .join('\n\n')
 
@@ -221,7 +261,7 @@ export function generateToolCatalog(tools: McpToolDefinitionListItem[]): {
     originalName: info.originalName,
     description: info.description,
     signature: info.methodSignature,
-    interfaceDecl: info.interfaceDecl || undefined,
+    interfaceDecl: [info.interfaceDecl, info.outputInterfaceDecl].filter(Boolean).join('\n\n') || undefined,
   }))
 
   return { entries, toolNameMap: buildToolNameMap(toolInfos) }

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
@@ -25,7 +25,7 @@ export interface CodeModeOptions {
   progressive?: boolean
   /**
    * Custom description template for the `code` tool.
-   * Supports placeholders: `{{types}}` (type definitions), `{{count}}` (tool count).
+   * Supports placeholders: `{{types}}` (type definitions), `{{count}}` (tool count), `{{example}}` (usage example).
    */
   description?: string
 }
@@ -247,7 +247,7 @@ export function generateTypesFromTools(tools: McpToolDefinitionListItem[]): Gene
     .join('\n\n')
 
   const methods = toolInfos
-    .map(t => `  ${t.methodSignature}`)
+    .map(t => `  ${t.methodSignature.replace(/ \/\/.*$/, '').trimEnd()}`)
     .join('\n')
 
   const codemodeDecl = `declare const codemode: {\n${methods}\n};`

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
@@ -49,7 +49,7 @@ function pascalCase(str: string): string {
 }
 
 function formatTsPropertyKey(key: string): string {
-  return /^[A-Za-z_$][\w$]*$/.test(key) && !RESERVED_WORDS.has(key)
+  return /^[A-Z_$][\w$]*$/i.test(key) && !RESERVED_WORDS.has(key)
     ? key
     : JSON.stringify(key)
 }

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z, type ZodRawShape } from 'zod'
 import type { McpToolDefinition, McpToolDefinitionListItem } from '../definitions/tools'
 import { enrichNameTitle } from '../definitions/utils'
 
@@ -112,7 +112,7 @@ interface SchemaTypeInfo {
 }
 
 function generateSchemaTypeInfo(
-  schema: Record<string, z.ZodTypeAny>,
+  schema: ZodRawShape,
   typeName: string,
 ): SchemaTypeInfo | null {
   const jsonSchema = z.toJSONSchema(z.object(schema))

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
@@ -31,9 +31,9 @@ export interface CodeModeOptions {
   description?: string
 }
 
-export type ExecuteResult =
-  | { result: unknown, error?: undefined, logs: string[], durationMs: number }
-  | { result?: undefined, error: string, logs: string[], durationMs: number }
+export type ExecuteResult
+  = | { result: unknown, error?: undefined, logs: string[], durationMs: number }
+    | { result?: undefined, error: string, logs: string[], durationMs: number }
 
 const RESERVED_WORDS = new Set([
   'break', 'case', 'catch', 'continue', 'debugger', 'default', 'delete', 'do',

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
@@ -1,5 +1,5 @@
 import { z, type ZodRawShape } from 'zod'
-import type { McpToolDefinition, McpToolDefinitionListItem } from '../definitions/tools'
+import type { McpToolAnnotations, McpToolDefinition, McpToolDefinitionListItem } from '../definitions/tools'
 import { enrichNameTitle } from '../definitions/utils'
 
 export interface CodeModeOptions {
@@ -25,7 +25,8 @@ export interface CodeModeOptions {
   progressive?: boolean
   /**
    * Custom description template for the `code` tool.
-   * Supports placeholders: `{{types}}` (type definitions), `{{count}}` (tool count), `{{example}}` (usage example).
+   * Supports placeholders: `{{types}}` (type definitions), `{{count}}` (tool count),
+   * `{{example}}` (usage example).
    */
   description?: string
 }
@@ -156,6 +157,15 @@ function generateSchemaTypeInfo(
   }
 }
 
+function buildAnnotationTags(annotations?: McpToolAnnotations): string[] {
+  if (!annotations) return []
+  const tags: string[] = []
+  if (annotations.readOnlyHint === true) tags.push('[read-only]')
+  if (annotations.destructiveHint === true) tags.push('[destructive]')
+  if (annotations.idempotentHint === true) tags.push('[idempotent]')
+  return tags
+}
+
 interface ToolTypeInfo {
   originalName: string
   sanitizedName: string
@@ -163,6 +173,8 @@ interface ToolTypeInfo {
   interfaceDecl: string | null
   outputInterfaceDecl: string | null
   methodSignature: string
+  /** True when hint or annotations are set — comment should be preserved in type block. */
+  preserveComment: boolean
 }
 
 function generateToolTypeInfo(tool: McpToolDefinition): ToolTypeInfo {
@@ -210,7 +222,11 @@ function generateToolTypeInfo(tool: McpToolDefinition): ToolTypeInfo {
     }
   }
 
-  const desc = tool.description ? ` // ${tool.description}` : ''
+  const annotationTags = buildAnnotationTags(tool.annotations)
+  const commentText = tool.description
+  const commentParts = [...annotationTags, ...(commentText ? [commentText] : [])]
+  const desc = commentParts.length > 0 ? ` // ${commentParts.join(' ')}` : ''
+
   const methodSignature = `${sanitizedName}: (${paramSignature}) => Promise<${returnType}>;${desc}`
 
   return {
@@ -220,6 +236,7 @@ function generateToolTypeInfo(tool: McpToolDefinition): ToolTypeInfo {
     interfaceDecl,
     outputInterfaceDecl,
     methodSignature,
+    preserveComment: annotationTags.length > 0,
   }
 }
 
@@ -251,7 +268,7 @@ export function generateTypesFromTools(tools: McpToolDefinitionListItem[]): Gene
     .join('\n\n')
 
   const methods = toolInfos
-    .map(t => `  ${t.methodSignature.replace(/ \/\/.*$/, '').trimEnd()}`)
+    .map(t => `  ${t.preserveComment ? t.methodSignature.trimEnd() : t.methodSignature.replace(/ \/\/.*$/, '').trimEnd()}`)
     .join('\n')
 
   const codemodeDecl = `declare const codemode: {\n${methods}\n};`
@@ -267,6 +284,8 @@ export interface ToolCatalogEntry {
   description: string
   signature: string
   interfaceDecl?: string
+  group?: string
+  annotations?: string[]
 }
 
 export function generateToolCatalog(tools: McpToolDefinitionListItem[]): {
@@ -278,13 +297,18 @@ export function generateToolCatalog(tools: McpToolDefinitionListItem[]): {
     return { ...info, description: tool.description || '' }
   })
 
-  const entries: ToolCatalogEntry[] = toolInfos.map(info => ({
-    name: info.sanitizedName,
-    originalName: info.originalName,
-    description: info.description,
-    signature: info.methodSignature,
-    interfaceDecl: [info.interfaceDecl, info.outputInterfaceDecl].filter(Boolean).join('\n\n') || undefined,
-  }))
+  const entries: ToolCatalogEntry[] = toolInfos.map((info, i) => {
+    const tool = tools[i]!
+    return {
+      name: info.sanitizedName,
+      originalName: info.originalName,
+      description: info.description,
+      signature: info.methodSignature,
+      interfaceDecl: [info.interfaceDecl, info.outputInterfaceDecl].filter(Boolean).join('\n\n') || undefined,
+      group: tool.group ?? (tool._meta?.group as string | undefined),
+      annotations: buildAnnotationTags(tool.annotations),
+    }
+  })
 
   return { entries, toolNameMap: buildToolNameMap(toolInfos) }
 }
@@ -318,23 +342,54 @@ export function searchToolCatalog(entries: ToolCatalogEntry[], query: string): T
   return scored.map(s => s.entry)
 }
 
+function formatToolEntry(m: ToolCatalogEntry): string {
+  return m.interfaceDecl
+    ? `${m.interfaceDecl}\n\ncodemode.${m.signature}`
+    : `codemode.${m.signature}`
+}
+
 export function formatSearchResults(matches: ToolCatalogEntry[], query: string, total: number): string {
   if (matches.length === 0) {
     return `No tools found matching "${query}". ${total} tools available — try a broader query.`
   }
 
-  const lines = matches.map((m) => {
-    const sig = m.interfaceDecl
-      ? `${m.interfaceDecl}\n\ncodemode.${m.signature}`
-      : `codemode.${m.signature}`
-    return sig
-  })
-
   const header = matches.length === total
     ? `All ${total} tools:`
     : `Found ${matches.length}/${total} tools matching "${query}":`
 
-  return `${header}\n\n${lines.join('\n\n')}`
+  const hasGroups = matches.some(m => m.group)
+
+  if (!hasGroups) {
+    const lines = matches.map(formatToolEntry)
+    return `${header}\n\n${lines.join('\n\n')}`
+  }
+
+  // Group by group field, ungrouped tools last
+  const grouped = new Map<string, ToolCatalogEntry[]>()
+  const ungrouped: ToolCatalogEntry[] = []
+
+  for (const m of matches) {
+    if (m.group) {
+      const list = grouped.get(m.group)
+      if (list) list.push(m)
+      else grouped.set(m.group, [m])
+    }
+    else {
+      ungrouped.push(m)
+    }
+  }
+
+  const sections: string[] = []
+  for (const [group, entries] of grouped) {
+    const lines = entries.map(formatToolEntry)
+    sections.push(`## ${group}\n\n${lines.join('\n\n')}`)
+  }
+  if (ungrouped.length > 0) {
+    const lines = ungrouped.map(formatToolEntry)
+    sections.push(lines.join('\n\n'))
+  }
+
+  return `${header}\n\n${sections.join('\n\n')}`
 }
 
 export { sanitizeToolName }

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
@@ -173,8 +173,6 @@ interface ToolTypeInfo {
   interfaceDecl: string | null
   outputInterfaceDecl: string | null
   methodSignature: string
-  /** True when hint or annotations are set — comment should be preserved in type block. */
-  preserveComment: boolean
 }
 
 function generateToolTypeInfo(tool: McpToolDefinition): ToolTypeInfo {
@@ -236,7 +234,6 @@ function generateToolTypeInfo(tool: McpToolDefinition): ToolTypeInfo {
     interfaceDecl,
     outputInterfaceDecl,
     methodSignature,
-    preserveComment: annotationTags.length > 0,
   }
 }
 
@@ -245,8 +242,9 @@ function buildToolNameMap(infos: ToolTypeInfo[]): Map<string, string> {
   for (const info of infos) {
     const existing = map.get(info.sanitizedName)
     if (existing && existing !== info.originalName) {
-      throw new Error(
-        `[nuxt-mcp-toolkit] Code Mode tool name collision: "${existing}" and "${info.originalName}" both sanitize to "${info.sanitizedName}". Rename one of the tools.`,
+      console.warn(
+        `[nuxt-mcp-toolkit] Code Mode tool name collision: "${existing}" and "${info.originalName}" both sanitize to "${info.sanitizedName}". `
+        + `Only the last tool will be available. Rename one of the tools to avoid this. This will become an error in a future version.`,
       )
     }
     map.set(info.sanitizedName, info.originalName)
@@ -268,7 +266,7 @@ export function generateTypesFromTools(tools: McpToolDefinitionListItem[]): Gene
     .join('\n\n')
 
   const methods = toolInfos
-    .map(t => `  ${t.preserveComment ? t.methodSignature.trimEnd() : t.methodSignature.replace(/ \/\/.*$/, '').trimEnd()}`)
+    .map(t => `  ${t.methodSignature.trimEnd()}`)
     .join('\n')
 
   const codemodeDecl = `declare const codemode: {\n${methods}\n};`

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
@@ -48,6 +48,12 @@ function pascalCase(str: string): string {
   return str.replace(/(^|_)(\w)/g, (_, __, c) => c.toUpperCase())
 }
 
+function formatTsPropertyKey(key: string): string {
+  return /^[A-Za-z_$][\w$]*$/.test(key) && !RESERVED_WORDS.has(key)
+    ? key
+    : JSON.stringify(key)
+}
+
 function jsonSchemaPropertyToTs(prop: Record<string, unknown>): string {
   if (prop.enum && Array.isArray(prop.enum)) {
     return prop.enum.map(v => typeof v === 'string' ? `"${v}"` : String(v)).join(' | ')
@@ -100,6 +106,50 @@ function isPrimitiveProp(prop: Record<string, unknown>): boolean {
   return !!type && PRIMITIVE_TYPES.has(type)
 }
 
+interface SchemaTypeInfo {
+  interfaceDecl: string | null
+  typeExpression: string
+}
+
+function generateSchemaTypeInfo(
+  schema: Record<string, z.ZodTypeAny>,
+  typeName: string,
+): SchemaTypeInfo | null {
+  const jsonSchema = z.toJSONSchema(z.object(schema))
+  const properties = jsonSchema.properties as Record<string, Record<string, unknown>> | undefined
+  const required = (jsonSchema.required as string[]) || []
+
+  if (!properties || Object.keys(properties).length === 0) {
+    return null
+  }
+
+  const entries = Object.entries(properties)
+  const allPrimitive = entries.every(([, prop]) => isPrimitiveProp(prop))
+
+  if (entries.length <= INLINE_THRESHOLD && allPrimitive) {
+    const inlineFields = entries.map(([key, prop]) => {
+      const opt = required.includes(key) ? '' : '?'
+      return `${formatTsPropertyKey(key)}${opt}: ${jsonSchemaPropertyToTs(prop)}`
+    })
+
+    return {
+      interfaceDecl: null,
+      typeExpression: `{ ${inlineFields.join('; ')} }`,
+    }
+  }
+
+  const fields = entries.map(([key, prop]) => {
+    const opt = required.includes(key) ? '' : '?'
+    const tsType = jsonSchemaPropertyToTs(prop)
+    return `  ${formatTsPropertyKey(key)}${opt}: ${tsType};`
+  })
+
+  return {
+    interfaceDecl: `interface ${typeName} {\n${fields.join('\n')}\n}`,
+    typeExpression: typeName,
+  }
+}
+
 interface ToolTypeInfo {
   originalName: string
   sanitizedName: string
@@ -125,30 +175,10 @@ function generateToolTypeInfo(tool: McpToolDefinition): ToolTypeInfo {
 
   if (tool.inputSchema && Object.keys(tool.inputSchema).length > 0) {
     try {
-      const jsonSchema = z.toJSONSchema(z.object(tool.inputSchema))
-      const properties = jsonSchema.properties as Record<string, Record<string, unknown>> | undefined
-      const required = (jsonSchema.required as string[]) || []
-
-      if (properties && Object.keys(properties).length > 0) {
-        const entries = Object.entries(properties)
-        const allPrimitive = entries.every(([, prop]) => isPrimitiveProp(prop))
-
-        if (entries.length <= INLINE_THRESHOLD && allPrimitive) {
-          const inlineFields = entries.map(([key, prop]) => {
-            const opt = required.includes(key) ? '' : '?'
-            return `${key}${opt}: ${jsonSchemaPropertyToTs(prop)}`
-          })
-          paramSignature = `input: { ${inlineFields.join('; ')} }`
-        }
-        else {
-          const fields = entries.map(([key, prop]) => {
-            const opt = required.includes(key) ? '' : '?'
-            const tsType = jsonSchemaPropertyToTs(prop)
-            return `  ${key}${opt}: ${tsType};`
-          })
-          interfaceDecl = `interface ${typeName} {\n${fields.join('\n')}\n}`
-          paramSignature = `input: ${typeName}`
-        }
+      const schemaTypeInfo = generateSchemaTypeInfo(tool.inputSchema, typeName)
+      if (schemaTypeInfo) {
+        interfaceDecl = schemaTypeInfo.interfaceDecl
+        paramSignature = `input: ${schemaTypeInfo.typeExpression}`
       }
     }
     catch {
@@ -163,30 +193,10 @@ function generateToolTypeInfo(tool: McpToolDefinition): ToolTypeInfo {
 
   if (tool.outputSchema && Object.keys(tool.outputSchema).length > 0) {
     try {
-      const jsonSchema = z.toJSONSchema(z.object(tool.outputSchema))
-      const properties = jsonSchema.properties as Record<string, Record<string, unknown>> | undefined
-      const required = (jsonSchema.required as string[]) || []
-
-      if (properties && Object.keys(properties).length > 0) {
-        const entries = Object.entries(properties)
-        const allPrimitive = entries.every(([, prop]) => isPrimitiveProp(prop))
-
-        if (entries.length <= INLINE_THRESHOLD && allPrimitive) {
-          const inlineFields = entries.map(([key, prop]) => {
-            const opt = required.includes(key) ? '' : '?'
-            return `${key}${opt}: ${jsonSchemaPropertyToTs(prop)}`
-          })
-          returnType = `{ ${inlineFields.join('; ')} }`
-        }
-        else {
-          const fields = entries.map(([key, prop]) => {
-            const opt = required.includes(key) ? '' : '?'
-            const tsType = jsonSchemaPropertyToTs(prop)
-            return `  ${key}${opt}: ${tsType};`
-          })
-          outputInterfaceDecl = `interface ${outputTypeName} {\n${fields.join('\n')}\n}`
-          returnType = outputTypeName
-        }
+      const schemaTypeInfo = generateSchemaTypeInfo(tool.outputSchema, outputTypeName)
+      if (schemaTypeInfo) {
+        outputInterfaceDecl = schemaTypeInfo.interfaceDecl
+        returnType = schemaTypeInfo.typeExpression
       }
     }
     catch {

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
@@ -30,12 +30,9 @@ export interface CodeModeOptions {
   description?: string
 }
 
-export interface ExecuteResult {
-  result: unknown
-  error?: string
-  logs: string[]
-  durationMs: number
-}
+export type ExecuteResult =
+  | { result: unknown, error?: undefined, logs: string[], durationMs: number }
+  | { result?: undefined, error: string, logs: string[], durationMs: number }
 
 const RESERVED_WORDS = new Set([
   'break', 'case', 'catch', 'continue', 'debugger', 'default', 'delete', 'do',
@@ -65,7 +62,7 @@ function formatTsPropertyKey(key: string): string {
 
 function jsonSchemaPropertyToTs(prop: Record<string, unknown>): string {
   if (prop.enum && Array.isArray(prop.enum)) {
-    return prop.enum.map(v => typeof v === 'string' ? `"${v}"` : String(v)).join(' | ')
+    return prop.enum.map(v => typeof v === 'string' ? JSON.stringify(v) : String(v)).join(' | ')
   }
 
   const type = prop.type as string | string[] | undefined

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
@@ -9,6 +9,14 @@ export interface CodeModeOptions {
   cpuTimeLimitMs?: number
   /** Max result size in bytes before truncation. Default: 102400 (100KB) */
   maxResultSize?: number
+  /** Max bytes accepted in a single RPC request body from the sandbox. Default: 1_048_576 (1MB) */
+  maxRequestBodyBytes?: number
+  /** Max bytes for a single tool RPC response before truncation. Default: 1_048_576 (1MB) */
+  maxToolResponseSize?: number
+  /** Wall-clock timeout for the entire execution in ms. Default: 60_000 (60s) */
+  wallTimeLimitMs?: number
+  /** Max tool RPC calls per execution. Default: 200 */
+  maxToolCalls?: number
   /**
    * Enable progressive disclosure: exposes a `search` tool for discovering
    * available tools, keeping the `code` tool description lightweight.

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/codemode/types.ts
@@ -34,6 +34,7 @@ export interface ExecuteResult {
   result: unknown
   error?: string
   logs: string[]
+  durationMs: number
 }
 
 const RESERVED_WORDS = new Set([
@@ -78,7 +79,7 @@ function jsonSchemaPropertyToTs(prop: Record<string, unknown>): string {
     const required = (prop.required as string[]) || []
     const fields = Object.entries(props).map(([key, value]) => {
       const opt = required.includes(key) ? '' : '?'
-      return `${key}${opt}: ${jsonSchemaPropertyToTs(value)}`
+      return `${formatTsPropertyKey(key)}${opt}: ${jsonSchemaPropertyToTs(value)}`
     })
     return `{ ${fields.join('; ')} }`
   }
@@ -228,6 +229,12 @@ function generateToolTypeInfo(tool: McpToolDefinition): ToolTypeInfo {
 function buildToolNameMap(infos: ToolTypeInfo[]): Map<string, string> {
   const map = new Map<string, string>()
   for (const info of infos) {
+    const existing = map.get(info.sanitizedName)
+    if (existing && existing !== info.originalName) {
+      throw new Error(
+        `[nuxt-mcp-toolkit] Code Mode tool name collision: "${existing}" and "${info.originalName}" both sanitize to "${info.sanitizedName}". Rename one of the tools.`,
+      )
+    }
     map.set(info.sanitizedName, info.originalName)
   }
   return map

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/handlers.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/handlers.ts
@@ -118,6 +118,11 @@ export interface McpHandlerOptions {
    *
    * This feature is experimental and may change in future releases.
    * Requires `secure-exec` to be installed: `npm install secure-exec`
+   * Code Mode also requires Node.js >=18.16.0 for AsyncLocalStorage context restoration.
+   *
+   * Pass `true` for defaults, or a `CodeModeOptions` object to configure limits:
+   * `memoryLimit`, `cpuTimeLimitMs`, `maxResultSize`, `maxRequestBodyBytes`,
+   * `maxToolResponseSize`, `wallTimeLimitMs`, `maxToolCalls`, `progressive`, `description`.
    *
    * @example
    * ```ts

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/results.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/results.ts
@@ -9,7 +9,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
  */
 export type McpToolCallbackResult = CallToolResult | string | number | boolean | Record<string, unknown> | unknown[]
 
-function isCallToolResult(value: object): value is CallToolResult {
+export function isCallToolResult(value: object): value is CallToolResult {
   return (
     ('content' in value && Array.isArray((value as CallToolResult).content))
     || 'structuredContent' in value

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/results.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/results.ts
@@ -13,7 +13,7 @@ export function isCallToolResult(value: object): value is CallToolResult {
   return (
     ('content' in value && Array.isArray((value as CallToolResult).content))
     || 'structuredContent' in value
-    || 'isError' in value
+    || ('isError' in value && typeof (value as CallToolResult).isError === 'boolean')
   )
 }
 

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/tools.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/tools.ts
@@ -171,7 +171,7 @@ export async function invokeWrappedToolHandler(
   input: unknown,
   extra: McpRequestExtra,
 ): Promise<McpToolCallbackResult> {
-  if (tool.inputSchema && Object.keys(tool.inputSchema).length > 0) {
+  if (tool.inputSchema !== undefined) {
     return await handler(input ?? {}, extra) as McpToolCallbackResult
   }
 

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/tools.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/tools.ts
@@ -122,21 +122,27 @@ export function normalizeErrorToResult(error: unknown): CallToolResult {
 }
 
 /**
- * Register a tool from a McpToolDefinition
+ * Resolve the normalized tool name used by registration and code mode.
+ *
  * @internal
  */
-export function registerToolFromDefinition(
-  server: McpServer,
-  tool: McpToolDefinition,
-) {
-  const { name, title } = enrichNameTitle({
+export function resolveToolDefinitionName(tool: McpToolDefinition): string {
+  const { name } = enrichNameTitle({
     name: tool.name,
     title: tool.title,
     _meta: tool._meta,
     type: 'tool',
   })
+  return name
+}
 
-  // Wrap handler with cache if cache is defined
+/**
+ * Apply the shared registration wrappers that must also be used by code mode.
+ *
+ * @internal
+ */
+export function createWrappedToolHandler(tool: McpToolDefinition): (...args: unknown[]) => unknown {
+  const name = resolveToolDefinitionName(tool)
   let handler = tool.handler as (...args: unknown[]) => unknown
 
   if (tool.cache !== undefined) {
@@ -148,9 +154,46 @@ export function registerToolFromDefinition(
       : undefined
 
     const cacheOptions = createCacheOptions(tool.cache, `mcp-tool:${name}`, defaultGetKey)
-
     handler = wrapWithCache(handler, cacheOptions)
   }
+
+  return handler
+}
+
+/**
+ * Invoke a wrapped tool handler with the same argument shape used by the MCP SDK.
+ *
+ * @internal
+ */
+export async function invokeWrappedToolHandler(
+  tool: McpToolDefinition,
+  handler: (...args: unknown[]) => unknown,
+  input: unknown,
+  extra: McpRequestExtra,
+): Promise<McpToolCallbackResult> {
+  if (tool.inputSchema && Object.keys(tool.inputSchema).length > 0) {
+    return await handler(input ?? {}, extra) as McpToolCallbackResult
+  }
+
+  return await handler(extra) as McpToolCallbackResult
+}
+
+/**
+ * Register a tool from a McpToolDefinition
+ * @internal
+ */
+export function registerToolFromDefinition(
+  server: McpServer,
+  tool: McpToolDefinition,
+) {
+  const name = resolveToolDefinitionName(tool)
+  const { title } = enrichNameTitle({
+    name: tool.name,
+    title: tool.title,
+    _meta: tool._meta,
+    type: 'tool',
+  })
+  const handler = createWrappedToolHandler(tool)
 
   // Normalize returns and catch thrown errors into isError results
   const normalizedHandler: ToolCallback<ZodRawShape> = async (...args: unknown[]) => {

--- a/packages/nuxt-mcp-toolkit/test/codemode-executor.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode-executor.test.ts
@@ -163,6 +163,62 @@ describe('executor AsyncLocalStorage context', () => {
   })
 })
 
+describe('executor AsyncLocalStorage fallback', () => {
+  it('degrades gracefully when snapshot is unavailable (Node <18.16)', async () => {
+    const original = AsyncLocalStorage.snapshot
+    try {
+      // Simulate Node < 18.16 where snapshot does not exist
+      // @ts-expect-error -- deliberately removing static method
+      delete AsyncLocalStorage.snapshot
+
+      const serverMock = createServerMock()
+      const secureExec = createSecureExecMock(async (code: string) => {
+        const { token, execId } = extractExecMetadata(code)
+        const handler = serverMock.getRequestHandler()!
+        const returnRes = createMockResponse()
+        await invokeHandler(handler, createJsonRequest({ tool: '__return__', args: 'fallback-ok', execId }, token), returnRes.res)
+        return { code: 0 }
+      })
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const mod = await importExecutorWithMocks({
+        createServer: serverMock.createServer,
+        secureExecModule: secureExec.module,
+      })
+
+      const result = await mod.execute('return 1;', {})
+
+      expect(result.error).toBeUndefined()
+      expect(result.result).toBe('fallback-ok')
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('AsyncLocalStorage.snapshot unavailable'),
+      )
+
+      // Second call should not warn again
+      warnSpy.mockClear()
+      const secureExec2 = createSecureExecMock(async (code: string) => {
+        const { token, execId } = extractExecMetadata(code)
+        const handler = serverMock.getRequestHandler()!
+        const returnRes = createMockResponse()
+        await invokeHandler(handler, createJsonRequest({ tool: '__return__', args: 'second-ok', execId }, token), returnRes.res)
+        return { code: 0 }
+      })
+      vi.doMock('secure-exec', () => secureExec2.module)
+      const result2 = await mod.execute('return 2;', {})
+
+      expect(result2.error).toBeUndefined()
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('AsyncLocalStorage.snapshot unavailable'),
+      )
+
+      warnSpy.mockRestore()
+    }
+    finally {
+      AsyncLocalStorage.snapshot = original
+    }
+  })
+})
+
 describe('executor session isolation', () => {
   it('creates independent runtimes with per-execution limits', async () => {
     const { createServer } = createServerMock()

--- a/packages/nuxt-mcp-toolkit/test/codemode-executor.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode-executor.test.ts
@@ -1,0 +1,738 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { execute, dispose } from '../src/runtime/server/mcp/codemode/executor'
+
+const mockDisposers: Array<() => void> = []
+
+afterEach(() => {
+  for (const disposeMock of mockDisposers.splice(0)) {
+    disposeMock()
+  }
+  dispose()
+  vi.restoreAllMocks()
+  vi.resetModules()
+  vi.doUnmock('node:http')
+  vi.doUnmock('secure-exec')
+  vi.doUnmock('node:async_hooks')
+})
+
+function createJsonRequest(payload: unknown, token: string) {
+  return {
+    headers: { 'x-rpc-token': token },
+    async* [Symbol.asyncIterator]() {
+      yield JSON.stringify(payload)
+    },
+  }
+}
+
+function createThrowingRequest(token: string) {
+  return {
+    headers: { 'x-rpc-token': token },
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => {
+          throw new Error('stream read failed')
+        },
+      }
+    },
+  }
+}
+
+function createMockResponse() {
+  let statusCode = 0
+  let body = ''
+  const res = {
+    headersSent: false,
+    writableEnded: false,
+    writeHead: vi.fn((status: number) => {
+      statusCode = status
+      res.headersSent = true
+      return res
+    }),
+    end: vi.fn((chunk: string = '') => {
+      body = chunk
+      res.writableEnded = true
+      return res
+    }),
+    destroy: vi.fn(() => {
+      res.writableEnded = true
+    }),
+  }
+
+  return {
+    res,
+    get statusCode() {
+      return statusCode
+    },
+    get body() {
+      return body
+    },
+    get json() {
+      return body ? JSON.parse(body) as Record<string, unknown> : undefined
+    },
+  }
+}
+
+function extractExecMetadata(sandboxCode: string) {
+  const token = sandboxCode.match(/'x-rpc-token': '([^']+)'/)?.[1]
+  const execId = sandboxCode.match(/const __execId = "([^"]+)";/)?.[1]
+
+  if (!token || !execId) {
+    throw new Error('Failed to extract RPC metadata from sandbox code')
+  }
+
+  return { token, execId }
+}
+
+function createSecureExecMock(
+  execImpl: (sandboxCode: string, options?: { onStdio?: (event: { channel: string, message: string }) => void }) => Promise<{ code: number, errorMessage?: string }> | { code: number, errorMessage?: string },
+) {
+  const runtimeDispose = vi.fn()
+  const runtimeExec = vi.fn(execImpl)
+  const NodeRuntime = vi.fn(function MockNodeRuntime() {
+    return {
+      exec: runtimeExec,
+      dispose: runtimeDispose,
+    }
+  })
+
+  return {
+    module: {
+      NodeRuntime,
+      createNodeDriver: vi.fn(() => ({})),
+      createNodeRuntimeDriverFactory: vi.fn(() => ({})),
+    },
+    runtimeDispose,
+    runtimeExec,
+    NodeRuntime,
+  }
+}
+
+async function importExecutorWithMocks(options: {
+  createServer: (handler: (req: unknown, res: unknown) => void | Promise<void>) => unknown
+  secureExecModule: Record<string, unknown>
+  asyncHooksModule?: Record<string, unknown>
+}) {
+  vi.resetModules()
+  vi.doMock('node:http', () => ({
+    createServer: options.createServer,
+  }))
+  vi.doMock('secure-exec', () => options.secureExecModule)
+
+  if (options.asyncHooksModule) {
+    const asyncHooksModule = options.asyncHooksModule
+    vi.doMock('node:async_hooks', () => asyncHooksModule)
+  }
+
+  const mod = await import('../src/runtime/server/mcp/codemode/executor')
+  mockDisposers.push(() => mod.dispose())
+  return mod
+}
+
+async function invokeHandler(
+  handler: (req: unknown, res: unknown) => void | Promise<void>,
+  req: unknown,
+  res: unknown,
+) {
+  handler(req, res)
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe('executor concurrency', () => {
+  it('concurrent execute() calls dispatch to their own function maps', async () => {
+    const fnsA: Record<string, (args: unknown) => Promise<unknown>> = {
+      tool_a: async () => {
+        await new Promise(r => setTimeout(r, 50))
+        return 'result-A'
+      },
+    }
+
+    const fnsB: Record<string, (args: unknown) => Promise<unknown>> = {
+      tool_b: async () => {
+        await new Promise(r => setTimeout(r, 50))
+        return 'result-B'
+      },
+    }
+
+    const [resultA, resultB] = await Promise.all([
+      execute('const r = await codemode.tool_a(); return r;', fnsA),
+      execute('const r = await codemode.tool_b(); return r;', fnsB),
+    ])
+
+    // Regression: execution-scoped function maps must not be overwritten by concurrent calls.
+    expect(resultA.error).toBeUndefined()
+    expect(resultA.result).toBe('result-A')
+    expect(resultB.error).toBeUndefined()
+    expect(resultB.result).toBe('result-B')
+  })
+
+  it('concurrent execute() calls return results to the correct caller', { timeout: 15000 }, async () => {
+    const fnsA: Record<string, (args: unknown) => Promise<unknown>> = {
+      echo: async (args: unknown) => (args as { value: string }).value,
+    }
+
+    const fnsB: Record<string, (args: unknown) => Promise<unknown>> = {
+      echo: async (args: unknown) => (args as { value: string }).value,
+    }
+
+    const [resultA, resultB] = await Promise.all([
+      execute('return await codemode.echo({ value: "hello-A" });', fnsA),
+      execute('return await codemode.echo({ value: "hello-B" });', fnsB),
+    ])
+
+    // Regression: each execution keeps its own return callback and cannot steal a sibling result.
+    expect(resultA.result).toBe('hello-A')
+    expect(resultB.result).toBe('hello-B')
+  })
+})
+
+describe('executor AsyncLocalStorage context', () => {
+  it('tool dispatch preserves AsyncLocalStorage context from the caller', async () => {
+    const als = new AsyncLocalStorage<{ userId: string }>()
+
+    const warmupFns: Record<string, (args: unknown) => Promise<unknown>> = {
+      noop: async () => 'ok',
+    }
+    const warmup = await execute('return await codemode.noop();', warmupFns)
+    expect(warmup.error).toBeUndefined()
+
+    const fns: Record<string, (args: unknown) => Promise<unknown>> = {
+      get_user: async () => {
+        const store = als.getStore()
+        if (!store) {
+          throw new Error('AsyncLocalStorage context lost — no store available')
+        }
+        return store.userId
+      },
+    }
+
+    const result = await als.run({ userId: 'user-123' }, () =>
+      execute('return await codemode.get_user();', fns),
+    )
+
+    // Regression: the singleton RPC server must restore the caller context per execution.
+    expect(result.error).toBeUndefined()
+    expect(result.result).toBe('user-123')
+  })
+})
+
+describe('executor hardening', () => {
+  it('shares one RPC server across concurrent cold-start execute() calls', async () => {
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        setTimeout(callback, 0)
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4311 })),
+    }
+    const createServer = vi.fn(() => server)
+    const secureExec = createSecureExecMock(async () => ({ code: 0 }))
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    const [first, second] = await Promise.all([
+      mod.execute('return 1;', {}),
+      mod.execute('return 2;', {}),
+    ])
+
+    expect(first.error).toBeUndefined()
+    expect(second.error).toBeUndefined()
+    expect(createServer).toHaveBeenCalledTimes(1)
+    expect(server.listen).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns a normal ExecuteResult when RPC server startup fails and retries on the next call', async () => {
+    let attempt = 0
+    const createServer = vi.fn(() => {
+      attempt += 1
+      let startupErrorHandler: ((error: Error) => void) | undefined
+      const server = {
+        once: vi.fn((event: string, handler: (error: Error) => void) => {
+          if (event === 'error') startupErrorHandler = handler
+          return server
+        }),
+        off: vi.fn(() => server),
+        listen: vi.fn(() => {
+          const currentAttempt = attempt
+          queueMicrotask(() => {
+            startupErrorHandler?.(new Error(`listen failed ${currentAttempt}`))
+          })
+          return server
+        }),
+        close: vi.fn(),
+        address: vi.fn(() => ({ port: 4400 + attempt })),
+      }
+      return server
+    })
+    const secureExec = createSecureExecMock(async () => ({ code: 0 }))
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    const first = await mod.execute('return 1;', {})
+    const second = await mod.execute('return 2;', {})
+
+    expect(first.error).toContain('listen failed 1')
+    expect(second.error).toContain('listen failed 2')
+    expect(createServer).toHaveBeenCalledTimes(2)
+  })
+
+  it('contains request body stream failures inside the RPC handler', async () => {
+    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4312 })),
+    }
+    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
+      requestHandler = handler
+      return server
+    })
+    let sandboxCode = ''
+    const secureExec = createSecureExecMock(async (code: string) => {
+      sandboxCode = code
+      return { code: 0 }
+    })
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    await mod.execute('return 1;', {})
+
+    const { token } = extractExecMetadata(sandboxCode)
+    const response = createMockResponse()
+    await expect(invokeHandler(requestHandler!, createThrowingRequest(token), response.res)).resolves.toBeUndefined()
+
+    expect(response.statusCode).toBe(500)
+    expect(response.json?.error).toContain('stream read failed')
+  })
+
+  it('returns ExecuteResult errors when the sandbox runtime crashes', async () => {
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4313 })),
+    }
+    const createServer = vi.fn(() => server)
+    const secureExec = createSecureExecMock(async () => {
+      throw new Error('runtime crashed')
+    })
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    const result = await mod.execute('return 1;', {})
+
+    expect(result.error).toContain('runtime crashed')
+  })
+
+  it('keeps the first return value when a sandbox tries to return twice', async () => {
+    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4314 })),
+    }
+    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
+      requestHandler = handler
+      return server
+    })
+    const firstReturn = createMockResponse()
+    const duplicateReturn = createMockResponse()
+    const secureExec = createSecureExecMock(async (sandboxCode: string) => {
+      const { token, execId } = extractExecMetadata(sandboxCode)
+      await invokeHandler(requestHandler!, createJsonRequest({ tool: '__return__', args: 'first', execId }, token), firstReturn.res)
+      await invokeHandler(requestHandler!, createJsonRequest({ tool: '__return__', args: 'second', execId }, token), duplicateReturn.res)
+      return { code: 0 }
+    })
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    const result = await mod.execute('return "ignored";', {})
+
+    expect(result.result).toBe('first')
+    expect(firstReturn.statusCode).toBe(200)
+    expect(duplicateReturn.statusCode).toBe(400)
+    expect(duplicateReturn.json?.error).toContain('Return value already received')
+  })
+
+  it('can dispose the singleton state and create a fresh runtime on the next execute()', async () => {
+    const servers: Array<{ close: ReturnType<typeof vi.fn> }> = []
+    const createServer = vi.fn(() => {
+      const server = {
+        once: vi.fn(() => server),
+        off: vi.fn(() => server),
+        listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+          callback()
+          return server
+        }),
+        close: vi.fn(),
+        address: vi.fn(() => ({ port: 4315 + servers.length })),
+      }
+      servers.push(server)
+      return server
+    })
+    const secureExec = createSecureExecMock(async () => ({ code: 0 }))
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    await mod.execute('return 1;', {})
+    mod.dispose()
+    await mod.execute('return 2;', {})
+
+    expect(createServer).toHaveBeenCalledTimes(2)
+    expect(secureExec.NodeRuntime).toHaveBeenCalledTimes(2)
+    expect(servers[0]!.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects requests with invalid RPC token', async () => {
+    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4320 })),
+    }
+    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
+      requestHandler = handler
+      return server
+    })
+    let sandboxCode = ''
+    const secureExec = createSecureExecMock(async (code: string) => {
+      sandboxCode = code
+      return { code: 0 }
+    })
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    await mod.execute('return 1;', {})
+
+    const { token } = extractExecMetadata(sandboxCode)
+    const response = createMockResponse()
+    await invokeHandler(requestHandler!, createJsonRequest({ tool: 'test', args: null, execId: 'abc' }, token + 'wrong'), response.res)
+
+    expect(response.statusCode).toBe(403)
+    expect(response.json?.error).toBe('Forbidden')
+  })
+
+  it('rejects requests with unknown execId', async () => {
+    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4321 })),
+    }
+    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
+      requestHandler = handler
+      return server
+    })
+    let sandboxCode = ''
+    const secureExec = createSecureExecMock(async (code: string) => {
+      sandboxCode = code
+      return { code: 0 }
+    })
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    await mod.execute('return 1;', {})
+
+    const { token } = extractExecMetadata(sandboxCode)
+    const response = createMockResponse()
+    // After execute() completes, the execId is cleaned up from the map
+    await invokeHandler(requestHandler!, createJsonRequest({ tool: 'test', args: null, execId: 'stale-id' }, token), response.res)
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json?.error).toContain('Unknown execution')
+  })
+
+  it('rejects requests with missing execId', async () => {
+    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4322 })),
+    }
+    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
+      requestHandler = handler
+      return server
+    })
+    let sandboxCode = ''
+    const secureExec = createSecureExecMock(async (code: string) => {
+      sandboxCode = code
+      return { code: 0 }
+    })
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    await mod.execute('return 1;', {})
+
+    const { token } = extractExecMetadata(sandboxCode)
+    const response = createMockResponse()
+    await invokeHandler(requestHandler!, createJsonRequest({ tool: 'test', args: null, execId: '' }, token), response.res)
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json?.error).toContain('Missing execution id')
+  })
+
+  it('returns 413 when RPC request body exceeds size limit', async () => {
+    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4323 })),
+    }
+    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
+      requestHandler = handler
+      return server
+    })
+    let sandboxCode = ''
+    const secureExec = createSecureExecMock(async (code: string) => {
+      sandboxCode = code
+      return { code: 0 }
+    })
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    // Use a tiny maxRequestBodyBytes to trigger the limit easily
+    await mod.execute('return 1;', {}, { maxRequestBodyBytes: 50 })
+
+    const { token } = extractExecMetadata(sandboxCode)
+    const largePayload = { tool: 'test', args: 'x'.repeat(200), execId: 'abc' }
+    const response = createMockResponse()
+    await invokeHandler(requestHandler!, createJsonRequest(largePayload, token), response.res)
+
+    expect(response.statusCode).toBe(413)
+    expect(response.json?.error).toContain('size limit')
+  })
+
+  it('returns 408 when wall-clock deadline is exceeded', async () => {
+    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4324 })),
+    }
+    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
+      requestHandler = handler
+      return server
+    })
+    const secureExec = createSecureExecMock(async (code: string) => {
+      // Simulate a long-running sandbox that makes an RPC call after the deadline
+      const { token, execId } = extractExecMetadata(code)
+      // Wait to ensure deadline passes
+      await new Promise(r => setTimeout(r, 50))
+      const toolResponse = createMockResponse()
+      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'slow_tool', args: null, execId }, token), toolResponse.res)
+      expect(toolResponse.statusCode).toBe(408)
+      return { code: 0 }
+    })
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    // Wall time of 1ms — will expire almost immediately
+    await mod.execute('return await codemode.slow_tool();', { slow_tool: async () => 'ok' }, { wallTimeLimitMs: 1 })
+  })
+
+  it('returns 429 when RPC call quota is exceeded', async () => {
+    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4325 })),
+    }
+    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
+      requestHandler = handler
+      return server
+    })
+    const secureExec = createSecureExecMock(async (code: string) => {
+      const { token, execId } = extractExecMetadata(code)
+
+      // Call 1 — should succeed
+      const r1 = createMockResponse()
+      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'my_tool', args: null, execId }, token), r1.res)
+      expect(r1.statusCode).toBe(200)
+
+      // Call 2 — should succeed
+      const r2 = createMockResponse()
+      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'my_tool', args: null, execId }, token), r2.res)
+      expect(r2.statusCode).toBe(200)
+
+      // Call 3 — should be rejected (quota is 2)
+      const r3 = createMockResponse()
+      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'my_tool', args: null, execId }, token), r3.res)
+      expect(r3.statusCode).toBe(429)
+      expect(r3.json?.error).toContain('Tool call limit exceeded')
+
+      return { code: 0 }
+    })
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    await mod.execute('return 1;', { my_tool: async () => 'ok' }, { maxToolCalls: 2 })
+  })
+
+  it('truncates oversized tool RPC responses', async () => {
+    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4326 })),
+    }
+    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
+      requestHandler = handler
+      return server
+    })
+    const secureExec = createSecureExecMock(async (code: string) => {
+      const { token, execId } = extractExecMetadata(code)
+
+      const response = createMockResponse()
+      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'big_tool', args: null, execId }, token), response.res)
+      expect(response.statusCode).toBe(200)
+      expect(response.json?.result).toHaveProperty('_truncated', true)
+
+      return { code: 0 }
+    })
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    const bigArray = Array.from({ length: 10000 }, (_, i) => `item-${i}`)
+    await mod.execute('return 1;', { big_tool: async () => bigArray }, { maxToolResponseSize: 500 })
+  })
+
+  it('sanitizes file paths in error messages returned to the sandbox', async () => {
+    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4327 })),
+    }
+    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
+      requestHandler = handler
+      return server
+    })
+    const secureExec = createSecureExecMock(async (code: string) => {
+      const { token, execId } = extractExecMetadata(code)
+
+      const response = createMockResponse()
+      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'fail_tool', args: null, execId }, token), response.res)
+      expect(response.statusCode).toBe(500)
+      // The path should be sanitized
+      expect(response.json?.error).toContain('[path]')
+      expect(response.json?.error).not.toContain('/Users/dev/project/src/secret.ts')
+
+      return { code: 0 }
+    })
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    await mod.execute('return 1;', {
+      fail_tool: async () => { throw new Error('Failed at /Users/dev/project/src/secret.ts:42') },
+    })
+  })
+
+  it('returns a clear error when AsyncLocalStorage.snapshot() is unavailable', async () => {
+    const AsyncLocalStorageWithoutSnapshot = function AsyncLocalStorageWithoutSnapshot() {}
+    Object.assign(AsyncLocalStorageWithoutSnapshot, { snapshot: undefined })
+
+    const createServer = vi.fn(() => ({
+      once: vi.fn(),
+      off: vi.fn(),
+      listen: vi.fn(),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 4316 })),
+    }))
+    const secureExec = createSecureExecMock(async () => ({ code: 0 }))
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+      asyncHooksModule: { AsyncLocalStorage: AsyncLocalStorageWithoutSnapshot },
+    })
+
+    const result = await mod.execute('return 1;', {})
+
+    expect(result.error).toContain('Node.js >=18.16.0')
+    expect(createServer).not.toHaveBeenCalled()
+  })
+})

--- a/packages/nuxt-mcp-toolkit/test/codemode-executor.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode-executor.test.ts
@@ -1,19 +1,13 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { execute, dispose } from '../src/runtime/server/mcp/codemode/executor'
-
-const mockDisposers: Array<() => void> = []
+import { dispose, execute } from '../src/runtime/server/mcp/codemode/executor'
 
 afterEach(() => {
-  for (const disposeMock of mockDisposers.splice(0)) {
-    disposeMock()
-  }
   dispose()
   vi.restoreAllMocks()
   vi.resetModules()
   vi.doUnmock('node:http')
   vi.doUnmock('secure-exec')
-  vi.doUnmock('node:async_hooks')
 })
 
 function createJsonRequest(payload: unknown, token: string) {
@@ -25,22 +19,10 @@ function createJsonRequest(payload: unknown, token: string) {
   }
 }
 
-function createThrowingRequest(token: string) {
-  return {
-    headers: { 'x-rpc-token': token },
-    [Symbol.asyncIterator]() {
-      return {
-        next: async () => {
-          throw new Error('stream read failed')
-        },
-      }
-    },
-  }
-}
-
 function createMockResponse() {
   let statusCode = 0
   let body = ''
+
   const res = {
     headersSent: false,
     writableEnded: false,
@@ -64,9 +46,6 @@ function createMockResponse() {
     get statusCode() {
       return statusCode
     },
-    get body() {
-      return body
-    },
     get json() {
       return body ? JSON.parse(body) as Record<string, unknown> : undefined
     },
@@ -84,16 +63,43 @@ function extractExecMetadata(sandboxCode: string) {
   return { token, execId }
 }
 
+function createServerMock(portStart = 4300) {
+  let requestHandler: ((req: unknown, res: unknown) => void | Promise<void>) | undefined
+  let nextPort = portStart
+
+  const createServer = vi.fn((handler: (req: unknown, res: unknown) => void | Promise<void>) => {
+    requestHandler = handler
+    const server = {
+      once: vi.fn(() => server),
+      off: vi.fn(() => server),
+      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
+        callback()
+        return server
+      }),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: nextPort++ })),
+    }
+    return server
+  })
+
+  return {
+    createServer,
+    getRequestHandler: () => requestHandler,
+  }
+}
+
 function createSecureExecMock(
   execImpl: (sandboxCode: string, options?: { onStdio?: (event: { channel: string, message: string }) => void }) => Promise<{ code: number, errorMessage?: string }> | { code: number, errorMessage?: string },
 ) {
-  const runtimeDispose = vi.fn()
-  const runtimeExec = vi.fn(execImpl)
+  const runtimes: Array<{ exec: ReturnType<typeof vi.fn>, dispose: ReturnType<typeof vi.fn> }> = []
+
   const NodeRuntime = vi.fn(function MockNodeRuntime() {
-    return {
-      exec: runtimeExec,
-      dispose: runtimeDispose,
+    const runtime = {
+      exec: vi.fn(execImpl),
+      dispose: vi.fn(),
     }
+    runtimes.push(runtime)
+    return runtime
   })
 
   return {
@@ -102,31 +108,21 @@ function createSecureExecMock(
       createNodeDriver: vi.fn(() => ({})),
       createNodeRuntimeDriverFactory: vi.fn(() => ({})),
     },
-    runtimeDispose,
-    runtimeExec,
     NodeRuntime,
+    runtimes,
   }
 }
 
 async function importExecutorWithMocks(options: {
   createServer: (handler: (req: unknown, res: unknown) => void | Promise<void>) => unknown
   secureExecModule: Record<string, unknown>
-  asyncHooksModule?: Record<string, unknown>
 }) {
   vi.resetModules()
   vi.doMock('node:http', () => ({
     createServer: options.createServer,
   }))
   vi.doMock('secure-exec', () => options.secureExecModule)
-
-  if (options.asyncHooksModule) {
-    const asyncHooksModule = options.asyncHooksModule
-    vi.doMock('node:async_hooks', () => asyncHooksModule)
-  }
-
-  const mod = await import('../src/runtime/server/mcp/codemode/executor')
-  mockDisposers.push(() => mod.dispose())
-  return mod
+  return await import('../src/runtime/server/mcp/codemode/executor')
 }
 
 async function invokeHandler(
@@ -139,338 +135,151 @@ async function invokeHandler(
 }
 
 describe('executor concurrency', () => {
-  it('concurrent execute() calls dispatch to their own function maps', async () => {
-    const fnsA: Record<string, (args: unknown) => Promise<unknown>> = {
-      tool_a: async () => {
-        await new Promise(r => setTimeout(r, 50))
-        return 'result-A'
-      },
-    }
-
-    const fnsB: Record<string, (args: unknown) => Promise<unknown>> = {
-      tool_b: async () => {
-        await new Promise(r => setTimeout(r, 50))
-        return 'result-B'
-      },
-    }
-
+  it('concurrent execute() calls keep dispatch isolated', async () => {
     const [resultA, resultB] = await Promise.all([
-      execute('const r = await codemode.tool_a(); return r;', fnsA),
-      execute('const r = await codemode.tool_b(); return r;', fnsB),
+      execute('return await codemode.tool_a();', { tool_a: async () => 'result-A' }),
+      execute('return await codemode.tool_b();', { tool_b: async () => 'result-B' }),
     ])
 
-    // Regression: execution-scoped function maps must not be overwritten by concurrent calls.
     expect(resultA.error).toBeUndefined()
     expect(resultA.result).toBe('result-A')
     expect(resultB.error).toBeUndefined()
     expect(resultB.result).toBe('result-B')
   })
-
-  it('concurrent execute() calls return results to the correct caller', { timeout: 15000 }, async () => {
-    const fnsA: Record<string, (args: unknown) => Promise<unknown>> = {
-      echo: async (args: unknown) => (args as { value: string }).value,
-    }
-
-    const fnsB: Record<string, (args: unknown) => Promise<unknown>> = {
-      echo: async (args: unknown) => (args as { value: string }).value,
-    }
-
-    const [resultA, resultB] = await Promise.all([
-      execute('return await codemode.echo({ value: "hello-A" });', fnsA),
-      execute('return await codemode.echo({ value: "hello-B" });', fnsB),
-    ])
-
-    // Regression: each execution keeps its own return callback and cannot steal a sibling result.
-    expect(resultA.result).toBe('hello-A')
-    expect(resultB.result).toBe('hello-B')
-  })
 })
 
 describe('executor AsyncLocalStorage context', () => {
-  it('tool dispatch preserves AsyncLocalStorage context from the caller', async () => {
+  it('preserves the caller async context during tool dispatch', async () => {
     const als = new AsyncLocalStorage<{ userId: string }>()
 
-    const warmupFns: Record<string, (args: unknown) => Promise<unknown>> = {
-      noop: async () => 'ok',
-    }
-    const warmup = await execute('return await codemode.noop();', warmupFns)
-    expect(warmup.error).toBeUndefined()
-
-    const fns: Record<string, (args: unknown) => Promise<unknown>> = {
-      get_user: async () => {
-        const store = als.getStore()
-        if (!store) {
-          throw new Error('AsyncLocalStorage context lost — no store available')
-        }
-        return store.userId
-      },
-    }
-
     const result = await als.run({ userId: 'user-123' }, () =>
-      execute('return await codemode.get_user();', fns),
+      execute('return await codemode.get_user();', {
+        get_user: async () => als.getStore()?.userId,
+      }),
     )
 
-    // Regression: the singleton RPC server must restore the caller context per execution.
     expect(result.error).toBeUndefined()
     expect(result.result).toBe('user-123')
   })
 })
 
-describe('executor hardening', () => {
-  it('shares one RPC server across concurrent cold-start execute() calls', async () => {
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        setTimeout(callback, 0)
-        return server
-      }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4311 })),
-    }
-    const createServer = vi.fn(() => server)
+describe('executor session isolation', () => {
+  it('creates independent runtimes with per-execution limits', async () => {
+    const { createServer } = createServerMock()
     const secureExec = createSecureExecMock(async () => ({ code: 0 }))
     const mod = await importExecutorWithMocks({
       createServer,
       secureExecModule: secureExec.module,
     })
 
-    const [first, second] = await Promise.all([
+    await mod.execute('return 1;', {}, { memoryLimit: 32, cpuTimeLimitMs: 500 })
+    await mod.execute('return 2;', {}, { memoryLimit: 128, cpuTimeLimitMs: 4000 })
+
+    const runtimeCalls = secureExec.NodeRuntime.mock.calls as unknown as Array<[Record<string, unknown>]>
+
+    expect(createServer).toHaveBeenCalledTimes(2)
+    expect(secureExec.NodeRuntime).toHaveBeenCalledTimes(2)
+    expect(runtimeCalls[0]![0]).toMatchObject({ memoryLimit: 32, cpuTimeLimitMs: 500 })
+    expect(runtimeCalls[1]![0]).toMatchObject({ memoryLimit: 128, cpuTimeLimitMs: 4000 })
+  })
+
+  it('creates independent RPC servers for concurrent cold starts', async () => {
+    const { createServer } = createServerMock()
+    const secureExec = createSecureExecMock(async () => ({ code: 0 }))
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
+    })
+
+    await Promise.all([
       mod.execute('return 1;', {}),
       mod.execute('return 2;', {}),
     ])
 
-    expect(first.error).toBeUndefined()
-    expect(second.error).toBeUndefined()
-    expect(createServer).toHaveBeenCalledTimes(1)
-    expect(server.listen).toHaveBeenCalledTimes(1)
-  })
-
-  it('returns a normal ExecuteResult when RPC server startup fails and retries on the next call', async () => {
-    let attempt = 0
-    const createServer = vi.fn(() => {
-      attempt += 1
-      let startupErrorHandler: ((error: Error) => void) | undefined
-      const server = {
-        once: vi.fn((event: string, handler: (error: Error) => void) => {
-          if (event === 'error') startupErrorHandler = handler
-          return server
-        }),
-        off: vi.fn(() => server),
-        listen: vi.fn(() => {
-          const currentAttempt = attempt
-          queueMicrotask(() => {
-            startupErrorHandler?.(new Error(`listen failed ${currentAttempt}`))
-          })
-          return server
-        }),
-        close: vi.fn(),
-        address: vi.fn(() => ({ port: 4400 + attempt })),
-      }
-      return server
-    })
-    const secureExec = createSecureExecMock(async () => ({ code: 0 }))
-    const mod = await importExecutorWithMocks({
-      createServer,
-      secureExecModule: secureExec.module,
-    })
-
-    const first = await mod.execute('return 1;', {})
-    const second = await mod.execute('return 2;', {})
-
-    expect(first.error).toContain('listen failed 1')
-    expect(second.error).toContain('listen failed 2')
     expect(createServer).toHaveBeenCalledTimes(2)
   })
+})
 
-  it('contains request body stream failures inside the RPC handler', async () => {
-    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        callback()
-        return server
+describe('executor hardening', () => {
+  it('enforces wall-clock timeouts per execution', async () => {
+    const { createServer } = createServerMock()
+    const secureExec = createSecureExecMock(() =>
+      new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('disposed')), 25)
       }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4312 })),
-    }
-    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
-      requestHandler = handler
-      return server
+    )
+    const mod = await importExecutorWithMocks({
+      createServer,
+      secureExecModule: secureExec.module,
     })
+
+    const result = await mod.execute('return 1;', {}, { wallTimeLimitMs: 5 })
+
+    expect(result.error).toBe('Execution wall-clock timeout exceeded')
+  })
+
+  it('rejects duplicate return deliveries', async () => {
+    const serverMock = createServerMock()
     let sandboxCode = ''
-    const secureExec = createSecureExecMock(async (code: string) => {
-      sandboxCode = code
-      return { code: 0 }
-    })
-    const mod = await importExecutorWithMocks({
-      createServer,
-      secureExecModule: secureExec.module,
-    })
-
-    await mod.execute('return 1;', {})
-
-    const { token } = extractExecMetadata(sandboxCode)
-    const response = createMockResponse()
-    await expect(invokeHandler(requestHandler!, createThrowingRequest(token), response.res)).resolves.toBeUndefined()
-
-    expect(response.statusCode).toBe(500)
-    expect(response.json?.error).toContain('stream read failed')
-  })
-
-  it('returns ExecuteResult errors when the sandbox runtime crashes', async () => {
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        callback()
-        return server
-      }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4313 })),
-    }
-    const createServer = vi.fn(() => server)
-    const secureExec = createSecureExecMock(async () => {
-      throw new Error('runtime crashed')
-    })
-    const mod = await importExecutorWithMocks({
-      createServer,
-      secureExecModule: secureExec.module,
-    })
-
-    const result = await mod.execute('return 1;', {})
-
-    expect(result.error).toContain('runtime crashed')
-  })
-
-  it('keeps the first return value when a sandbox tries to return twice', async () => {
-    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        callback()
-        return server
-      }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4314 })),
-    }
-    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
-      requestHandler = handler
-      return server
-    })
     const firstReturn = createMockResponse()
     const duplicateReturn = createMockResponse()
-    const secureExec = createSecureExecMock(async (sandboxCode: string) => {
-      const { token, execId } = extractExecMetadata(sandboxCode)
-      await invokeHandler(requestHandler!, createJsonRequest({ tool: '__return__', args: 'first', execId }, token), firstReturn.res)
-      await invokeHandler(requestHandler!, createJsonRequest({ tool: '__return__', args: 'second', execId }, token), duplicateReturn.res)
+    const secureExec = createSecureExecMock(async (code: string) => {
+      sandboxCode = code
+      const { token, execId } = extractExecMetadata(code)
+      const handler = serverMock.getRequestHandler()!
+
+      await invokeHandler(handler, createJsonRequest({ tool: '__return__', args: 'first', execId }, token), firstReturn.res)
+      await invokeHandler(handler, createJsonRequest({ tool: '__return__', args: 'second', execId }, token), duplicateReturn.res)
       return { code: 0 }
     })
     const mod = await importExecutorWithMocks({
-      createServer,
+      createServer: serverMock.createServer,
       secureExecModule: secureExec.module,
     })
 
     const result = await mod.execute('return "ignored";', {})
 
+    expect(sandboxCode).toContain('__execId')
     expect(result.result).toBe('first')
     expect(firstReturn.statusCode).toBe(200)
     expect(duplicateReturn.statusCode).toBe(400)
-    expect(duplicateReturn.json?.error).toContain('Return value already received')
   })
 
-  it('can dispose the singleton state and create a fresh runtime on the next execute()', async () => {
-    const servers: Array<{ close: ReturnType<typeof vi.fn> }> = []
-    const createServer = vi.fn(() => {
-      const server = {
-        once: vi.fn(() => server),
-        off: vi.fn(() => server),
-        listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-          callback()
-          return server
-        }),
-        close: vi.fn(),
-        address: vi.fn(() => ({ port: 4315 + servers.length })),
-      }
-      servers.push(server)
-      return server
-    })
-    const secureExec = createSecureExecMock(async () => ({ code: 0 }))
-    const mod = await importExecutorWithMocks({
-      createServer,
-      secureExecModule: secureExec.module,
-    })
-
-    await mod.execute('return 1;', {})
-    mod.dispose()
-    await mod.execute('return 2;', {})
-
-    expect(createServer).toHaveBeenCalledTimes(2)
-    expect(secureExec.NodeRuntime).toHaveBeenCalledTimes(2)
-    expect(servers[0]!.close).toHaveBeenCalledTimes(1)
-  })
-
-  it('rejects requests with invalid RPC token', async () => {
-    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        callback()
-        return server
-      }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4320 })),
-    }
-    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
-      requestHandler = handler
-      return server
-    })
+  it('rejects invalid RPC tokens', async () => {
+    const serverMock = createServerMock()
     let sandboxCode = ''
     const secureExec = createSecureExecMock(async (code: string) => {
       sandboxCode = code
       return { code: 0 }
     })
     const mod = await importExecutorWithMocks({
-      createServer,
+      createServer: serverMock.createServer,
       secureExecModule: secureExec.module,
     })
 
     await mod.execute('return 1;', {})
 
-    const { token } = extractExecMetadata(sandboxCode)
+    const { token, execId } = extractExecMetadata(sandboxCode)
     const response = createMockResponse()
-    await invokeHandler(requestHandler!, createJsonRequest({ tool: 'test', args: null, execId: 'abc' }, token + 'wrong'), response.res)
+    await invokeHandler(
+      serverMock.getRequestHandler()!,
+      createJsonRequest({ tool: 'noop', args: null, execId }, `${token}-wrong`),
+      response.res,
+    )
 
     expect(response.statusCode).toBe(403)
     expect(response.json?.error).toBe('Forbidden')
   })
 
-  it('rejects requests with unknown execId', async () => {
-    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        callback()
-        return server
-      }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4321 })),
-    }
-    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
-      requestHandler = handler
-      return server
-    })
+  it('rejects unknown execution ids', async () => {
+    const serverMock = createServerMock()
     let sandboxCode = ''
     const secureExec = createSecureExecMock(async (code: string) => {
       sandboxCode = code
       return { code: 0 }
     })
     const mod = await importExecutorWithMocks({
-      createServer,
+      createServer: serverMock.createServer,
       secureExecModule: secureExec.module,
     })
 
@@ -478,36 +287,25 @@ describe('executor hardening', () => {
 
     const { token } = extractExecMetadata(sandboxCode)
     const response = createMockResponse()
-    // After execute() completes, the execId is cleaned up from the map
-    await invokeHandler(requestHandler!, createJsonRequest({ tool: 'test', args: null, execId: 'stale-id' }, token), response.res)
+    await invokeHandler(
+      serverMock.getRequestHandler()!,
+      createJsonRequest({ tool: 'noop', args: null, execId: 'stale-id' }, token),
+      response.res,
+    )
 
     expect(response.statusCode).toBe(400)
     expect(response.json?.error).toContain('Unknown execution')
   })
 
-  it('rejects requests with missing execId', async () => {
-    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        callback()
-        return server
-      }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4322 })),
-    }
-    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
-      requestHandler = handler
-      return server
-    })
+  it('rejects missing execution ids', async () => {
+    const serverMock = createServerMock()
     let sandboxCode = ''
     const secureExec = createSecureExecMock(async (code: string) => {
       sandboxCode = code
       return { code: 0 }
     })
     const mod = await importExecutorWithMocks({
-      createServer,
+      createServer: serverMock.createServer,
       secureExecModule: secureExec.module,
     })
 
@@ -515,224 +313,87 @@ describe('executor hardening', () => {
 
     const { token } = extractExecMetadata(sandboxCode)
     const response = createMockResponse()
-    await invokeHandler(requestHandler!, createJsonRequest({ tool: 'test', args: null, execId: '' }, token), response.res)
+    await invokeHandler(
+      serverMock.getRequestHandler()!,
+      createJsonRequest({ tool: 'noop', args: null, execId: '' }, token),
+      response.res,
+    )
 
     expect(response.statusCode).toBe(400)
     expect(response.json?.error).toContain('Missing execution id')
   })
 
-  it('returns 413 when RPC request body exceeds size limit', async () => {
-    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        callback()
-        return server
-      }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4323 })),
-    }
-    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
-      requestHandler = handler
-      return server
-    })
+  it('enforces request body size limits', async () => {
+    const serverMock = createServerMock()
     let sandboxCode = ''
     const secureExec = createSecureExecMock(async (code: string) => {
       sandboxCode = code
       return { code: 0 }
     })
     const mod = await importExecutorWithMocks({
-      createServer,
+      createServer: serverMock.createServer,
       secureExecModule: secureExec.module,
     })
 
-    // Use a tiny maxRequestBodyBytes to trigger the limit easily
-    await mod.execute('return 1;', {}, { maxRequestBodyBytes: 50 })
+    await mod.execute('return 1;', {}, { maxRequestBodyBytes: 20 })
 
-    const { token } = extractExecMetadata(sandboxCode)
-    const largePayload = { tool: 'test', args: 'x'.repeat(200), execId: 'abc' }
+    const { token, execId } = extractExecMetadata(sandboxCode)
     const response = createMockResponse()
-    await invokeHandler(requestHandler!, createJsonRequest(largePayload, token), response.res)
+    await invokeHandler(
+      serverMock.getRequestHandler()!,
+      createJsonRequest({ tool: 'noop', args: 'x'.repeat(200), execId }, token),
+      response.res,
+    )
 
     expect(response.statusCode).toBe(413)
-    expect(response.json?.error).toContain('size limit')
+    expect(response.json?.error).toContain('Request body exceeds size limit')
   })
 
-  it('returns 408 when wall-clock deadline is exceeded', async () => {
-    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        callback()
-        return server
-      }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4324 })),
-    }
-    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
-      requestHandler = handler
-      return server
-    })
+  it('enforces tool-call quotas', async () => {
+    const serverMock = createServerMock()
+    const first = createMockResponse()
+    const second = createMockResponse()
     const secureExec = createSecureExecMock(async (code: string) => {
-      // Simulate a long-running sandbox that makes an RPC call after the deadline
       const { token, execId } = extractExecMetadata(code)
-      // Wait to ensure deadline passes
-      await new Promise(r => setTimeout(r, 50))
-      const toolResponse = createMockResponse()
-      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'slow_tool', args: null, execId }, token), toolResponse.res)
-      expect(toolResponse.statusCode).toBe(408)
+      const handler = serverMock.getRequestHandler()!
+
+      await invokeHandler(handler, createJsonRequest({ tool: 'ping', args: null, execId }, token), first.res)
+      await invokeHandler(handler, createJsonRequest({ tool: 'ping', args: null, execId }, token), second.res)
       return { code: 0 }
     })
     const mod = await importExecutorWithMocks({
-      createServer,
+      createServer: serverMock.createServer,
       secureExecModule: secureExec.module,
     })
 
-    // Wall time of 1ms — will expire almost immediately
-    await mod.execute('return await codemode.slow_tool();', { slow_tool: async () => 'ok' }, { wallTimeLimitMs: 1 })
+    await mod.execute('return 1;', { ping: async () => 'pong' }, { maxToolCalls: 1 })
+
+    expect(first.statusCode).toBe(200)
+    expect(second.statusCode).toBe(429)
   })
 
-  it('returns 429 when RPC call quota is exceeded', async () => {
-    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        callback()
-        return server
-      }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4325 })),
-    }
-    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
-      requestHandler = handler
-      return server
-    })
+  it('truncates oversized tool responses', async () => {
+    const serverMock = createServerMock()
+    const response = createMockResponse()
     const secureExec = createSecureExecMock(async (code: string) => {
       const { token, execId } = extractExecMetadata(code)
-
-      // Call 1 — should succeed
-      const r1 = createMockResponse()
-      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'my_tool', args: null, execId }, token), r1.res)
-      expect(r1.statusCode).toBe(200)
-
-      // Call 2 — should succeed
-      const r2 = createMockResponse()
-      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'my_tool', args: null, execId }, token), r2.res)
-      expect(r2.statusCode).toBe(200)
-
-      // Call 3 — should be rejected (quota is 2)
-      const r3 = createMockResponse()
-      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'my_tool', args: null, execId }, token), r3.res)
-      expect(r3.statusCode).toBe(429)
-      expect(r3.json?.error).toContain('Tool call limit exceeded')
-
+      await invokeHandler(
+        serverMock.getRequestHandler()!,
+        createJsonRequest({ tool: 'big', args: null, execId }, token),
+        response.res,
+      )
       return { code: 0 }
     })
     const mod = await importExecutorWithMocks({
-      createServer,
-      secureExecModule: secureExec.module,
-    })
-
-    await mod.execute('return 1;', { my_tool: async () => 'ok' }, { maxToolCalls: 2 })
-  })
-
-  it('truncates oversized tool RPC responses', async () => {
-    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        callback()
-        return server
-      }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4326 })),
-    }
-    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
-      requestHandler = handler
-      return server
-    })
-    const secureExec = createSecureExecMock(async (code: string) => {
-      const { token, execId } = extractExecMetadata(code)
-
-      const response = createMockResponse()
-      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'big_tool', args: null, execId }, token), response.res)
-      expect(response.statusCode).toBe(200)
-      expect(response.json?.result).toHaveProperty('_truncated', true)
-
-      return { code: 0 }
-    })
-    const mod = await importExecutorWithMocks({
-      createServer,
-      secureExecModule: secureExec.module,
-    })
-
-    const bigArray = Array.from({ length: 10000 }, (_, i) => `item-${i}`)
-    await mod.execute('return 1;', { big_tool: async () => bigArray }, { maxToolResponseSize: 500 })
-  })
-
-  it('sanitizes file paths in error messages returned to the sandbox', async () => {
-    let requestHandler: ((req: unknown, res: unknown) => Promise<void> | void) | undefined
-    const server = {
-      once: vi.fn(() => server),
-      off: vi.fn(() => server),
-      listen: vi.fn((_port: number, _host: string, callback: () => void) => {
-        callback()
-        return server
-      }),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4327 })),
-    }
-    const createServer = vi.fn((handler: (req: unknown, res: unknown) => Promise<void> | void) => {
-      requestHandler = handler
-      return server
-    })
-    const secureExec = createSecureExecMock(async (code: string) => {
-      const { token, execId } = extractExecMetadata(code)
-
-      const response = createMockResponse()
-      await invokeHandler(requestHandler!, createJsonRequest({ tool: 'fail_tool', args: null, execId }, token), response.res)
-      expect(response.statusCode).toBe(500)
-      // The path should be sanitized
-      expect(response.json?.error).toContain('[path]')
-      expect(response.json?.error).not.toContain('/Users/dev/project/src/secret.ts')
-
-      return { code: 0 }
-    })
-    const mod = await importExecutorWithMocks({
-      createServer,
+      createServer: serverMock.createServer,
       secureExecModule: secureExec.module,
     })
 
     await mod.execute('return 1;', {
-      fail_tool: async () => { throw new Error('Failed at /Users/dev/project/src/secret.ts:42') },
-    })
-  })
+      big: async () => Array.from({ length: 50 }, (_, index) => `item-${index}`),
+    }, { maxToolResponseSize: 60 })
 
-  it('returns a clear error when AsyncLocalStorage.snapshot() is unavailable', async () => {
-    const AsyncLocalStorageWithoutSnapshot = function AsyncLocalStorageWithoutSnapshot() {}
-    Object.assign(AsyncLocalStorageWithoutSnapshot, { snapshot: undefined })
-
-    const createServer = vi.fn(() => ({
-      once: vi.fn(),
-      off: vi.fn(),
-      listen: vi.fn(),
-      close: vi.fn(),
-      address: vi.fn(() => ({ port: 4316 })),
-    }))
-    const secureExec = createSecureExecMock(async () => ({ code: 0 }))
-    const mod = await importExecutorWithMocks({
-      createServer,
-      secureExecModule: secureExec.module,
-      asyncHooksModule: { AsyncLocalStorage: AsyncLocalStorageWithoutSnapshot },
-    })
-
-    const result = await mod.execute('return 1;', {})
-
-    expect(result.error).toContain('Node.js >=18.16.0')
-    expect(createServer).not.toHaveBeenCalled()
+    expect(response.statusCode).toBe(200)
+    expect(response.json?.result).toMatchObject({ _truncated: true })
   })
 })

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -77,12 +77,12 @@ describe('sanitizeToolName', () => {
 })
 
 describe('generateTypesFromTools', () => {
-  it('generates codemode declarations without inline description comments', () => {
+  it('generates codemode declarations with inline description comments', () => {
     const { typeDefinitions, toolNameMap } = generateTypesFromTools(sampleTools)
 
     expect(typeDefinitions).toContain('declare const codemode')
     expect(typeDefinitions).toContain('get_user')
-    expect(typeDefinitions).not.toContain('// Get a user by ID')
+    expect(typeDefinitions).toContain('// Get a user by ID')
     expect(toolNameMap.get('get_user')).toBe('get-user')
   })
 
@@ -103,11 +103,15 @@ describe('generateTypesFromTools', () => {
     expect(typeDefinitions).toContain('Promise<GetReportOutput>')
   })
 
-  it('throws on sanitized name collisions', () => {
-    expect(() => generateTypesFromTools([
+  it('warns on sanitized name collisions and keeps last tool', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { toolNameMap } = generateTypesFromTools([
       makeTool('get-user', 'A'),
       makeTool('get_user', 'B'),
-    ])).toThrow(/both sanitize to "get_user"/)
+    ])
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('both sanitize to "get_user"'))
+    expect(toolNameMap.get('get_user')).toBe('get_user') // last wins
+    warnSpy.mockRestore()
   })
 })
 
@@ -249,6 +253,45 @@ describe('buildDispatchFunctions', () => {
       sameSignal: true,
     })
   })
+
+  it('passes extra as second argument for empty-schema tools', async () => {
+    const extra = mockMcpExtra()
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'empty-schema-tool',
+      description: 'Tool with empty schema',
+      inputSchema: {},
+      handler: async (_args: Record<string, never>, receivedExtra: McpRequestExtra) => ({
+        hasExtra: receivedExtra !== undefined,
+        requestId: receivedExtra.requestId,
+      }),
+    }]
+    const { toolNameMap } = generateTypesFromTools(tools)
+    const fns = buildDispatchFunctions(tools, toolNameMap, extra)
+
+    await expect(fns.empty_schema_tool!({})).resolves.toEqual({
+      hasExtra: true,
+      requestId: 1,
+    })
+  })
+
+  it('passes extra as sole argument for undefined-schema tools', async () => {
+    const extra = mockMcpExtra()
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'no-schema-tool',
+      description: 'Tool without schema',
+      handler: async (receivedExtra: McpRequestExtra) => ({
+        hasExtra: receivedExtra !== undefined,
+        requestId: receivedExtra.requestId,
+      }),
+    }]
+    const { toolNameMap } = generateTypesFromTools(tools)
+    const fns = buildDispatchFunctions(tools, toolNameMap, extra)
+
+    await expect(fns.no_schema_tool!({})).resolves.toEqual({
+      hasExtra: true,
+      requestId: 1,
+    })
+  })
 })
 
 describe('code tool envelope', () => {
@@ -378,6 +421,28 @@ describe('buildDispatchFunctions error handling', () => {
       details: undefined,
     })
   })
+
+  it('preserves structuredContent details in error sentinel', async () => {
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'structured-fail',
+      description: 'Fails with structured error',
+      inputSchema: {},
+      handler: async () => ({
+        isError: true,
+        structuredContent: { code: 'FORBIDDEN', reason: 'Not authorized' },
+        content: [{ type: 'text' as const, text: 'Permission denied' }],
+      }),
+    }]
+    const { toolNameMap } = generateTypesFromTools(tools)
+    const fns = buildDispatchFunctions(tools, toolNameMap, mockMcpExtra())
+
+    await expect(fns.structured_fail!({})).resolves.toEqual({
+      __mcp_toolkit_error__: true,
+      message: 'Permission denied',
+      tool: 'structured_fail',
+      details: { code: 'FORBIDDEN', reason: 'Not authorized' },
+    })
+  })
 })
 
 describe('annotation surfacing', () => {
@@ -477,7 +542,7 @@ describe('backward compatibility', () => {
 })
 
 describe('annotation vs description comment boundary', () => {
-  it('preserves annotation tag comments but strips plain description comments', () => {
+  it('preserves descriptions for all tools, with annotation tags prepended when present', () => {
     const tools: McpToolDefinitionListItem[] = [
       {
         name: 'annotated-tool',
@@ -497,7 +562,7 @@ describe('annotation vs description comment boundary', () => {
 
     // Annotated tool: tag + description preserved
     expect(typeDefinitions).toContain('[read-only] This has annotations')
-    // Plain tool: description stripped from compact type block
-    expect(typeDefinitions).not.toContain('// This has no annotations')
+    // Plain tool: description also preserved
+    expect(typeDefinitions).toContain('// This has no annotations')
   })
 })

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -7,7 +7,7 @@ import {
   formatSearchResults,
   sanitizeToolName,
 } from '../src/runtime/server/mcp/codemode/types'
-import { createCodemodeTools, disposeCodeMode } from '../src/runtime/server/mcp/codemode/index'
+import { createCodemodeTools, disposeCodeMode, buildDispatchFunctions } from '../src/runtime/server/mcp/codemode/index'
 import { normalizeCode } from '../src/runtime/server/mcp/codemode/executor'
 import type { McpToolDefinition, McpToolDefinitionListItem } from '../src/runtime/server/mcp/definitions/tools'
 import type { McpRequestExtra } from '../src/runtime/server/mcp/definitions/sdk-extra'
@@ -459,6 +459,103 @@ describe('normalizeCode', () => {
   it('passes through plain code unchanged', () => {
     const code = 'const result = await codemode.list_users();\nreturn result;'
     expect(normalizeCode(code)).toBe(code)
+  })
+})
+
+describe('buildDispatchFunctions — error handling', () => {
+  it('returns __toolError sentinel for isError results', async () => {
+    const tool: McpToolDefinition = {
+      name: 'fail-tool',
+      description: 'A tool that fails',
+      inputSchema: { id: z.string() },
+      handler: async () => ({
+        isError: true,
+        content: [{ type: 'text' as const, text: 'Item not found' }],
+      }),
+    }
+    const { toolNameMap } = generateTypesFromTools([tool])
+    const fns = buildDispatchFunctions([tool], toolNameMap)
+    const result = await fns.fail_tool!({ id: 'nonexistent' }) as Record<string, unknown>
+
+    expect(result.__toolError).toBe(true)
+    expect(result.message).toBe('Item not found')
+    expect(result.tool).toBe('fail_tool')
+  })
+
+  it('includes structuredContent as details in error sentinel', async () => {
+    const tool: McpToolDefinition = {
+      name: 'validate-tool',
+      description: 'A validation tool',
+      inputSchema: { id: z.string() },
+      handler: async () => ({
+        isError: true,
+        structuredContent: { ok: false, error: { category: 'validation', retryable: false } },
+        content: [{ type: 'text' as const, text: 'Validation failed' }],
+      }),
+    }
+    const { toolNameMap } = generateTypesFromTools([tool])
+    const fns = buildDispatchFunctions([tool], toolNameMap)
+    const result = await fns.validate_tool!({ id: 'bad' }) as Record<string, unknown>
+
+    expect(result.__toolError).toBe(true)
+    expect(result.message).toBe('Validation failed')
+    expect(result.details).toEqual({ ok: false, error: { category: 'validation', retryable: false } })
+  })
+
+  it('error sentinel has no details when no structuredContent', async () => {
+    const tool: McpToolDefinition = {
+      name: 'simple-fail',
+      description: 'Simple failure',
+      inputSchema: {},
+      handler: async () => ({
+        isError: true,
+        content: [{ type: 'text' as const, text: 'Something went wrong' }],
+      }),
+    }
+    const { toolNameMap } = generateTypesFromTools([tool])
+    const fns = buildDispatchFunctions([tool], toolNameMap)
+    const result = await fns.simple_fail!({}) as Record<string, unknown>
+
+    expect(result.__toolError).toBe(true)
+    expect(result.message).toBe('Something went wrong')
+    expect(result.details).toBeUndefined()
+  })
+
+  it('non-error results are unaffected by error handling', async () => {
+    const tool: McpToolDefinition = {
+      name: 'ok-tool',
+      description: 'A tool that succeeds',
+      inputSchema: {},
+      handler: async () => ({
+        content: [{ type: 'text' as const, text: '{"status":"ok"}' }],
+      }),
+    }
+    const { toolNameMap } = generateTypesFromTools([tool])
+    const fns = buildDispatchFunctions([tool], toolNameMap)
+    const result = await fns.ok_tool!({})
+
+    expect(result).toEqual({ status: 'ok' })
+  })
+
+  it('isError with structuredContent prioritizes error over structured data', async () => {
+    const tool: McpToolDefinition = {
+      name: 'error-with-data',
+      description: 'Error with data',
+      inputSchema: {},
+      handler: async () => ({
+        isError: true,
+        structuredContent: { field: 'id', expected: 'valid ObjectId' },
+        content: [{ type: 'text' as const, text: 'Invalid ID format' }],
+      }),
+    }
+    const { toolNameMap } = generateTypesFromTools([tool])
+    const fns = buildDispatchFunctions([tool], toolNameMap)
+    const result = await fns.error_with_data!({}) as Record<string, unknown>
+
+    // Should be an error, not the structuredContent
+    expect(result.__toolError).toBe(true)
+    expect(result.message).toBe('Invalid ID format')
+    expect(result.details).toEqual({ field: 'id', expected: 'valid ObjectId' })
   })
 })
 

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -388,7 +388,7 @@ describe('enum escaping in type generation', () => {
       name: 'get-quote',
       description: 'Get a quote',
       inputSchema: {
-        style: z.enum(['he said "hello"', "it's fine", 'back\\slash']),
+        style: z.enum(['he said "hello"', 'it\'s fine', 'back\\slash']),
       },
       handler: async () => 'ok',
     }]

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -379,3 +379,125 @@ describe('buildDispatchFunctions error handling', () => {
     })
   })
 })
+
+describe('annotation surfacing', () => {
+  it('surfaces readOnlyHint as [read-only] tag', () => {
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'list-items',
+      description: 'List items',
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+      handler: async () => 'ok',
+    }]
+    const { typeDefinitions } = generateTypesFromTools(tools)
+    expect(typeDefinitions).toContain('[read-only]')
+  })
+
+  it('surfaces destructiveHint as [destructive] tag', () => {
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'delete-item',
+      description: 'Delete item',
+      inputSchema: { id: z.string() },
+      annotations: { destructiveHint: true },
+      handler: async () => 'ok',
+    }]
+    const { typeDefinitions } = generateTypesFromTools(tools)
+    expect(typeDefinitions).toContain('[destructive]')
+  })
+
+  it('surfaces idempotentHint as [idempotent] tag', () => {
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'update-item',
+      description: 'Update item',
+      inputSchema: { id: z.string() },
+      annotations: { idempotentHint: true },
+      handler: async () => 'ok',
+    }]
+    const { typeDefinitions } = generateTypesFromTools(tools)
+    expect(typeDefinitions).toContain('[idempotent]')
+  })
+
+  it('combines multiple annotation tags', () => {
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'safe-read',
+      description: 'Safe read',
+      inputSchema: {},
+      annotations: { readOnlyHint: true, idempotentHint: true },
+      handler: async () => 'ok',
+    }]
+    const { typeDefinitions } = generateTypesFromTools(tools)
+    expect(typeDefinitions).toContain('[read-only] [idempotent] Safe read')
+  })
+})
+
+describe('grouped search results', () => {
+  it('groups tools by group field with section headers', () => {
+    const tools: McpToolDefinitionListItem[] = [
+      { name: 'create-runbook', description: 'Create', inputSchema: {}, group: 'workspace', handler: async () => 'ok' },
+      { name: 'list-runbooks', description: 'List', inputSchema: {}, group: 'workspace', handler: async () => 'ok' },
+      { name: 'search-public', description: 'Search', inputSchema: {}, group: 'public', handler: async () => 'ok' },
+    ]
+    const { entries } = generateToolCatalog(tools)
+    const formatted = formatSearchResults(entries, '', entries.length)
+
+    expect(formatted).toContain('## workspace')
+    expect(formatted).toContain('## public')
+    expect(formatted).toContain('codemode.create_runbook')
+    expect(formatted).toContain('codemode.search_public')
+  })
+
+  it('renders mixed grouped and ungrouped tools correctly', () => {
+    const tools: McpToolDefinitionListItem[] = [
+      { name: 'create-item', description: 'Create', inputSchema: {}, group: 'items', handler: async () => 'ok' },
+      { name: 'get-status', description: 'Status', inputSchema: {}, handler: async () => 'ok' },
+    ]
+    const { entries } = generateToolCatalog(tools)
+    const formatted = formatSearchResults(entries, '', entries.length)
+
+    expect(formatted).toContain('## items')
+    expect(formatted).toContain('codemode.get_status')
+  })
+
+  it('renders flat when no tools have groups (backward compat)', () => {
+    const { entries } = generateToolCatalog(sampleTools)
+    const formatted = formatSearchResults(entries, '', entries.length)
+
+    expect(formatted).not.toContain('##')
+    expect(formatted).toContain('codemode.get_user')
+  })
+})
+
+describe('backward compatibility', () => {
+  it('tools without annotations work identically', () => {
+    const { typeDefinitions } = generateTypesFromTools(sampleTools)
+
+    expect(typeDefinitions).toContain('get_user')
+    expect(typeDefinitions).toContain('declare const codemode')
+  })
+})
+
+describe('annotation vs description comment boundary', () => {
+  it('preserves annotation tag comments but strips plain description comments', () => {
+    const tools: McpToolDefinitionListItem[] = [
+      {
+        name: 'annotated-tool',
+        description: 'This has annotations',
+        inputSchema: {},
+        annotations: { readOnlyHint: true },
+        handler: async () => 'ok',
+      },
+      {
+        name: 'plain-tool',
+        description: 'This has no annotations',
+        inputSchema: {},
+        handler: async () => 'ok',
+      },
+    ]
+    const { typeDefinitions } = generateTypesFromTools(tools)
+
+    // Annotated tool: tag + description preserved
+    expect(typeDefinitions).toContain('[read-only] This has annotations')
+    // Plain tool: description stripped from compact type block
+    expect(typeDefinitions).not.toContain('// This has no annotations')
+  })
+})

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -307,6 +307,114 @@ describe('createCodemodeTools', () => {
   })
 })
 
+describe('buildDispatchFunctions — structuredContent handling', () => {
+  it('returns structuredContent when present, not text content', async () => {
+    const tools: McpToolDefinition[] = [{
+      name: 'create-item',
+      description: 'Create an item',
+      inputSchema: { title: z.string() },
+      handler: async () => ({
+        structuredContent: { ok: true, data: { id: 'abc123' } },
+        content: [{ type: 'text' as const, text: 'Created item successfully' }],
+      }),
+    }]
+    const [codeTool] = createCodemodeTools(tools)
+    const result = await codeTool!.handler!({ code: 'return await codemode.create_item({ title: "Test" })' }, {})
+    const text = (result as { content: { text: string }[] }).content[0]!.text
+    const parsed = JSON.parse(text)
+
+    expect(parsed).toEqual({ ok: true, data: { id: 'abc123' } })
+  })
+
+  it('preserves typed fields (booleans, nested objects) from structuredContent', async () => {
+    const tools: McpToolDefinition[] = [{
+      name: 'get-status',
+      description: 'Get status',
+      inputSchema: {},
+      handler: async () => ({
+        structuredContent: { active: true, count: 42, nested: { a: [1, 2] } },
+        content: [{ type: 'text' as const, text: 'Status OK' }],
+      }),
+    }]
+    const [codeTool] = createCodemodeTools(tools)
+    const result = await codeTool!.handler!({ code: 'return await codemode.get_status()' }, {})
+    const text = (result as { content: { text: string }[] }).content[0]!.text
+    const parsed = JSON.parse(text)
+
+    expect(parsed.active).toBe(true)
+    expect(parsed.count).toBe(42)
+    expect(parsed.nested).toEqual({ a: [1, 2] })
+  })
+
+  it('enables operation chaining with structuredContent IDs', async () => {
+    const tools: McpToolDefinition[] = [
+      {
+        name: 'create-item',
+        description: 'Create an item',
+        inputSchema: { title: z.string() },
+        handler: async () => ({
+          structuredContent: { ok: true, data: { id: 'xyz789' } },
+          content: [{ type: 'text' as const, text: 'Created' }],
+        }),
+      },
+      {
+        name: 'update-item',
+        description: 'Update an item',
+        inputSchema: { id: z.string(), title: z.string() },
+        handler: async ({ id, title }: { id: string, title: string }) => ({
+          structuredContent: { ok: true, data: { id, title } },
+          content: [{ type: 'text' as const, text: `Updated ${id}` }],
+        }),
+      },
+    ]
+    const [codeTool] = createCodemodeTools(tools)
+    const result = await codeTool!.handler!({
+      code: `
+        const created = await codemode.create_item({ title: "Test" });
+        const updated = await codemode.update_item({ id: created.data.id, title: "Updated" });
+        return updated;
+      `,
+    }, {})
+    const text = (result as { content: { text: string }[] }).content[0]!.text
+    const parsed = JSON.parse(text)
+
+    expect(parsed).toEqual({ ok: true, data: { id: 'xyz789', title: 'Updated' } })
+  })
+
+  it('falls back to text content when structuredContent is absent', async () => {
+    const tools: McpToolDefinition[] = [{
+      name: 'echo',
+      description: 'Echo text',
+      inputSchema: { msg: z.string() },
+      handler: async ({ msg }: { msg: string }) => ({
+        content: [{ type: 'text' as const, text: msg }],
+      }),
+    }]
+    const [codeTool] = createCodemodeTools(tools)
+    const result = await codeTool!.handler!({ code: 'return await codemode.echo({ msg: "hello" })' }, {})
+    const text = (result as { content: { text: string }[] }).content[0]!.text
+
+    expect(text).toBe('hello')
+  })
+
+  it('handles structuredContent-only result (no content array)', async () => {
+    const tools: McpToolDefinition[] = [{
+      name: 'data-only',
+      description: 'Data only tool',
+      inputSchema: {},
+      handler: async () => ({
+        structuredContent: { value: 99 },
+      }),
+    }]
+    const [codeTool] = createCodemodeTools(tools)
+    const result = await codeTool!.handler!({ code: 'return await codemode.data_only()' }, {})
+    const text = (result as { content: { text: string }[] }).content[0]!.text
+    const parsed = JSON.parse(text)
+
+    expect(parsed).toEqual({ value: 99 })
+  })
+})
+
 describe('normalizeCode', () => {
   it('strips markdown fences', () => {
     const code = '```javascript\nconst x = 1;\n```'

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -97,6 +97,15 @@ describe('output type generation', () => {
     expect(typeDefinitions).not.toContain('interface CreateItemOutput')
   })
 
+  it('quotes output property names that are not TS-safe identifiers', () => {
+    const tools = [makeToolWithOutput('get-meta', 'Meta', {}, {
+      'repo-name': z.string(),
+      default: z.boolean(),
+    })]
+    const { typeDefinitions } = generateTypesFromTools(tools)
+    expect(typeDefinitions).toContain('Promise<{ "repo-name": string; "default": boolean }>')
+  })
+
   it('generates named output interface for complex schemas', () => {
     const tools = [makeToolWithOutput('get-report', 'Report', {}, {
       id: z.string(),

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -20,6 +20,21 @@ function makeTool(name: string, description: string, inputSchema?: Record<string
   }
 }
 
+function makeToolWithOutput(
+  name: string,
+  description: string,
+  inputSchema: Record<string, z.ZodTypeAny>,
+  outputSchema: Record<string, z.ZodTypeAny>,
+): McpToolDefinition {
+  return {
+    name,
+    description,
+    inputSchema,
+    outputSchema,
+    handler: async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }),
+  }
+}
+
 const sampleTools = [
   makeTool('get-user', 'Get a user by ID', { id: z.string() }),
   makeTool('list-users', 'List all users'),
@@ -71,6 +86,40 @@ describe('generateTypesFromTools', () => {
 
     expect(toolNameMap.get('delete_todo')).toBe('delete-todo')
     expect(toolNameMap.get('search_products')).toBe('search-products')
+  })
+})
+
+describe('output type generation', () => {
+  it('generates inline return type from small outputSchema', () => {
+    const tools = [makeToolWithOutput('create-item', 'Create', { title: z.string() }, { id: z.string(), ok: z.boolean() })]
+    const { typeDefinitions } = generateTypesFromTools(tools)
+    expect(typeDefinitions).toContain('Promise<{ id: string; ok: boolean }>')
+    expect(typeDefinitions).not.toContain('interface CreateItemOutput')
+  })
+
+  it('generates named output interface for complex schemas', () => {
+    const tools = [makeToolWithOutput('get-report', 'Report', {}, {
+      id: z.string(),
+      title: z.string(),
+      status: z.enum(['draft', 'published']),
+      views: z.number(),
+    })]
+    const { typeDefinitions } = generateTypesFromTools(tools)
+    expect(typeDefinitions).toContain('interface GetReportOutput')
+    expect(typeDefinitions).toContain('Promise<GetReportOutput>')
+  })
+
+  it('defaults to Promise<unknown> when no outputSchema', () => {
+    const tools = [makeTool('list-items', 'List items')]
+    const { typeDefinitions } = generateTypesFromTools(tools)
+    expect(typeDefinitions).toContain('Promise<unknown>')
+    expect(typeDefinitions).not.toContain('Output')
+  })
+
+  it('catalog entries reflect output types in signatures', () => {
+    const tools = [makeToolWithOutput('create-item', 'Create', { title: z.string() }, { id: z.string(), ok: z.boolean() })]
+    const { entries } = generateToolCatalog(tools)
+    expect(entries[0]!.signature).toContain('Promise<{ id: string; ok: boolean }>')
   })
 })
 

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -9,7 +9,17 @@ import {
 } from '../src/runtime/server/mcp/codemode/types'
 import { createCodemodeTools, disposeCodeMode } from '../src/runtime/server/mcp/codemode/index'
 import { normalizeCode } from '../src/runtime/server/mcp/codemode/executor'
-import type { McpToolDefinition } from '../src/runtime/server/mcp/definitions/tools'
+import type { McpToolDefinition, McpToolDefinitionListItem } from '../src/runtime/server/mcp/definitions/tools'
+import type { McpRequestExtra } from '../src/runtime/server/mcp/definitions/sdk-extra'
+
+function mockMcpExtra(): McpRequestExtra {
+  return {
+    signal: new AbortController().signal,
+    requestId: 0,
+    sendNotification: async () => {},
+    sendRequest: (async () => ({})) as McpRequestExtra['sendRequest'],
+  }
+}
 
 function makeTool(name: string, description: string, inputSchema?: Record<string, z.ZodTypeAny>): McpToolDefinition {
   return {
@@ -309,7 +319,7 @@ describe('createCodemodeTools', () => {
 
 describe('buildDispatchFunctions — structuredContent handling', () => {
   it('returns structuredContent when present, not text content', async () => {
-    const tools: McpToolDefinition[] = [{
+    const tools: McpToolDefinitionListItem[] = [{
       name: 'create-item',
       description: 'Create an item',
       inputSchema: { title: z.string() },
@@ -319,7 +329,7 @@ describe('buildDispatchFunctions — structuredContent handling', () => {
       }),
     }]
     const [codeTool] = createCodemodeTools(tools)
-    const result = await codeTool!.handler!({ code: 'return await codemode.create_item({ title: "Test" })' }, {})
+    const result = await codeTool!.handler!({ code: 'return await codemode.create_item({ title: "Test" })' }, mockMcpExtra())
     const text = (result as { content: { text: string }[] }).content[0]!.text
     const parsed = JSON.parse(text)
 
@@ -327,7 +337,7 @@ describe('buildDispatchFunctions — structuredContent handling', () => {
   })
 
   it('preserves typed fields (booleans, nested objects) from structuredContent', async () => {
-    const tools: McpToolDefinition[] = [{
+    const tools: McpToolDefinitionListItem[] = [{
       name: 'get-status',
       description: 'Get status',
       inputSchema: {},
@@ -337,7 +347,7 @@ describe('buildDispatchFunctions — structuredContent handling', () => {
       }),
     }]
     const [codeTool] = createCodemodeTools(tools)
-    const result = await codeTool!.handler!({ code: 'return await codemode.get_status()' }, {})
+    const result = await codeTool!.handler!({ code: 'return await codemode.get_status()' }, mockMcpExtra())
     const text = (result as { content: { text: string }[] }).content[0]!.text
     const parsed = JSON.parse(text)
 
@@ -347,7 +357,7 @@ describe('buildDispatchFunctions — structuredContent handling', () => {
   })
 
   it('enables operation chaining with structuredContent IDs', async () => {
-    const tools: McpToolDefinition[] = [
+    const tools: McpToolDefinitionListItem[] = [
       {
         name: 'create-item',
         description: 'Create an item',
@@ -361,9 +371,9 @@ describe('buildDispatchFunctions — structuredContent handling', () => {
         name: 'update-item',
         description: 'Update an item',
         inputSchema: { id: z.string(), title: z.string() },
-        handler: async ({ id, title }: { id: string, title: string }) => ({
-          structuredContent: { ok: true, data: { id, title } },
-          content: [{ type: 'text' as const, text: `Updated ${id}` }],
+        handler: async (args: Record<string, unknown>) => ({
+          structuredContent: { ok: true, data: { id: args.id, title: args.title } },
+          content: [{ type: 'text' as const, text: `Updated ${args.id}` }],
         }),
       },
     ]
@@ -374,7 +384,7 @@ describe('buildDispatchFunctions — structuredContent handling', () => {
         const updated = await codemode.update_item({ id: created.data.id, title: "Updated" });
         return updated;
       `,
-    }, {})
+    }, mockMcpExtra())
     const text = (result as { content: { text: string }[] }).content[0]!.text
     const parsed = JSON.parse(text)
 
@@ -382,23 +392,23 @@ describe('buildDispatchFunctions — structuredContent handling', () => {
   })
 
   it('falls back to text content when structuredContent is absent', async () => {
-    const tools: McpToolDefinition[] = [{
+    const tools: McpToolDefinitionListItem[] = [{
       name: 'echo',
       description: 'Echo text',
       inputSchema: { msg: z.string() },
-      handler: async ({ msg }: { msg: string }) => ({
-        content: [{ type: 'text' as const, text: msg }],
+      handler: async (args: Record<string, unknown>) => ({
+        content: [{ type: 'text' as const, text: args.msg as string }],
       }),
     }]
     const [codeTool] = createCodemodeTools(tools)
-    const result = await codeTool!.handler!({ code: 'return await codemode.echo({ msg: "hello" })' }, {})
+    const result = await codeTool!.handler!({ code: 'return await codemode.echo({ msg: "hello" })' }, mockMcpExtra())
     const text = (result as { content: { text: string }[] }).content[0]!.text
 
     expect(text).toBe('hello')
   })
 
   it('handles structuredContent-only result (no content array)', async () => {
-    const tools: McpToolDefinition[] = [{
+    const tools: McpToolDefinitionListItem[] = [{
       name: 'data-only',
       description: 'Data only tool',
       inputSchema: {},
@@ -407,7 +417,7 @@ describe('buildDispatchFunctions — structuredContent handling', () => {
       }),
     }]
     const [codeTool] = createCodemodeTools(tools)
-    const result = await codeTool!.handler!({ code: 'return await codemode.data_only()' }, {})
+    const result = await codeTool!.handler!({ code: 'return await codemode.data_only()' }, mockMcpExtra())
     const text = (result as { content: { text: string }[] }).content[0]!.text
     const parsed = JSON.parse(text)
 

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -100,7 +100,7 @@ describe('output type generation', () => {
   it('quotes output property names that are not TS-safe identifiers', () => {
     const tools = [makeToolWithOutput('get-meta', 'Meta', {}, {
       'repo-name': z.string(),
-      default: z.boolean(),
+      'default': z.boolean(),
     })]
     const { typeDefinitions } = generateTypesFromTools(tools)
     expect(typeDefinitions).toContain('Promise<{ "repo-name": string; "default": boolean }>')

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -1,27 +1,35 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import {
-  generateTypesFromTools,
-  generateToolCatalog,
-  searchToolCatalog,
   formatSearchResults,
+  generateToolCatalog,
+  generateTypesFromTools,
   sanitizeToolName,
 } from '../src/runtime/server/mcp/codemode/types'
-import { createCodemodeTools, disposeCodeMode, buildDispatchFunctions } from '../src/runtime/server/mcp/codemode/index'
+import { buildDispatchFunctions, createCodemodeTools, disposeCodeMode } from '../src/runtime/server/mcp/codemode/index'
 import { normalizeCode } from '../src/runtime/server/mcp/codemode/executor'
-import type { McpToolDefinition, McpToolDefinitionListItem } from '../src/runtime/server/mcp/definitions/tools'
 import type { McpRequestExtra } from '../src/runtime/server/mcp/definitions/sdk-extra'
+import type { McpToolDefinition, McpToolDefinitionListItem } from '../src/runtime/server/mcp/definitions/tools'
+
+vi.mock('../src/runtime/server/mcp/definitions/cache', () => ({
+  createCacheOptions: () => ({}),
+  wrapWithCache: <T>(fn: T) => fn,
+}))
 
 function mockMcpExtra(): McpRequestExtra {
   return {
     signal: new AbortController().signal,
-    requestId: 0,
+    requestId: 1,
     sendNotification: async () => {},
     sendRequest: (async () => ({})) as McpRequestExtra['sendRequest'],
   }
 }
 
-function makeTool(name: string, description: string, inputSchema?: Record<string, z.ZodTypeAny>): McpToolDefinition {
+function makeTool(
+  name: string,
+  description: string,
+  inputSchema?: Record<string, z.ZodTypeAny>,
+): McpToolDefinition {
   return {
     name,
     description,
@@ -53,574 +61,254 @@ const sampleTools = [
     completed: z.boolean().optional(),
   }),
   makeTool('delete-todo', 'Delete a todo by ID', { id: z.string() }),
-  makeTool('search-products', 'Search products catalog', {
-    query: z.string(),
-    category: z.string().optional(),
-    limit: z.number().optional(),
-  }),
 ]
 
-const manyTools = Array.from({ length: 11 }, (_, i) =>
-  makeTool(`tool-${i + 1}`, `Tool ${i + 1}`, { id: z.string() }),
-)
-
-const boundaryTools = Array.from({ length: 10 }, (_, i) =>
-  makeTool(`tool-${i + 1}`, `Tool ${i + 1}`, { id: z.string() }),
-)
+afterEach(() => {
+  disposeCodeMode()
+})
 
 describe('sanitizeToolName', () => {
-  it('replaces hyphens with underscores', () => {
+  it('sanitizes invalid identifier shapes', () => {
     expect(sanitizeToolName('get-user')).toBe('get_user')
-  })
-
-  it('prefixes names starting with digits', () => {
     expect(sanitizeToolName('123abc')).toBe('_123abc')
-  })
-
-  it('appends underscore to reserved words', () => {
     expect(sanitizeToolName('delete')).toBe('delete_')
-    expect(sanitizeToolName('class')).toBe('class_')
-  })
-
-  it('passes through valid names unchanged', () => {
-    expect(sanitizeToolName('myTool')).toBe('myTool')
   })
 })
 
 describe('generateTypesFromTools', () => {
-  it('generates type definitions for all tools', () => {
+  it('generates codemode declarations without inline description comments', () => {
     const { typeDefinitions, toolNameMap } = generateTypesFromTools(sampleTools)
 
     expect(typeDefinitions).toContain('declare const codemode')
     expect(typeDefinitions).toContain('get_user')
-    expect(typeDefinitions).toContain('list_users')
-    expect(typeDefinitions).toContain('create_todo')
-    expect(toolNameMap.size).toBe(5)
+    expect(typeDefinitions).not.toContain('// Get a user by ID')
     expect(toolNameMap.get('get_user')).toBe('get-user')
   })
 
-  it('maps sanitized names to originals', () => {
-    const { toolNameMap } = generateTypesFromTools(sampleTools)
-
-    expect(toolNameMap.get('delete_todo')).toBe('delete-todo')
-    expect(toolNameMap.get('search_products')).toBe('search-products')
-  })
-
-  it('omits description comments from the embedded type block', () => {
-    const { typeDefinitions } = generateTypesFromTools(sampleTools)
-
-    expect(typeDefinitions).toContain('get_user')
-    expect(typeDefinitions).not.toContain('// Get a user by ID')
-  })
-})
-
-describe('output type generation', () => {
-  it('generates inline return type from small outputSchema', () => {
-    const tools = [makeToolWithOutput('create-item', 'Create', { title: z.string() }, { id: z.string(), ok: z.boolean() })]
+  it('generates output types from outputSchema', () => {
+    const tools = [
+      makeToolWithOutput('create-item', 'Create item', { title: z.string() }, { id: z.string(), ok: z.boolean() }),
+      makeToolWithOutput('get-report', 'Get report', {}, {
+        id: z.string(),
+        title: z.string(),
+        status: z.enum(['draft', 'published']),
+        views: z.number(),
+      }),
+    ]
     const { typeDefinitions } = generateTypesFromTools(tools)
+
     expect(typeDefinitions).toContain('Promise<{ id: string; ok: boolean }>')
-    expect(typeDefinitions).not.toContain('interface CreateItemOutput')
-  })
-
-  it('quotes output property names that are not TS-safe identifiers', () => {
-    const tools = [makeToolWithOutput('get-meta', 'Meta', {}, {
-      'repo-name': z.string(),
-      'default': z.boolean(),
-    })]
-    const { typeDefinitions } = generateTypesFromTools(tools)
-    expect(typeDefinitions).toContain('Promise<{ "repo-name": string; "default": boolean }>')
-  })
-
-  it('generates named output interface for complex schemas', () => {
-    const tools = [makeToolWithOutput('get-report', 'Report', {}, {
-      id: z.string(),
-      title: z.string(),
-      status: z.enum(['draft', 'published']),
-      views: z.number(),
-    })]
-    const { typeDefinitions } = generateTypesFromTools(tools)
     expect(typeDefinitions).toContain('interface GetReportOutput')
     expect(typeDefinitions).toContain('Promise<GetReportOutput>')
   })
 
-  it('defaults to Promise<unknown> when no outputSchema', () => {
-    const tools = [makeTool('list-items', 'List items')]
-    const { typeDefinitions } = generateTypesFromTools(tools)
-    expect(typeDefinitions).toContain('Promise<unknown>')
-    expect(typeDefinitions).not.toContain('Output')
-  })
-
-  it('catalog entries reflect output types in signatures', () => {
-    const tools = [makeToolWithOutput('create-item', 'Create', { title: z.string() }, { id: z.string(), ok: z.boolean() })]
-    const { entries } = generateToolCatalog(tools)
-    expect(entries[0]!.signature).toContain('Promise<{ id: string; ok: boolean }>')
+  it('throws on sanitized name collisions', () => {
+    expect(() => generateTypesFromTools([
+      makeTool('get-user', 'A'),
+      makeTool('get_user', 'B'),
+    ])).toThrow(/both sanitize to "get_user"/)
   })
 })
 
 describe('generateToolCatalog', () => {
-  it('creates catalog entries for all tools', () => {
-    const { entries, toolNameMap } = generateToolCatalog(sampleTools)
+  it('keeps richer descriptions in catalog signatures', () => {
+    const tools = [makeToolWithOutput('create-item', 'Create item', { title: z.string() }, { id: z.string(), ok: z.boolean() })]
+    const { entries } = generateToolCatalog(tools)
 
-    expect(entries).toHaveLength(5)
-    expect(toolNameMap.size).toBe(5)
+    expect(entries[0]!.signature).toContain('Promise<{ id: string; ok: boolean }>')
+    expect(entries[0]!.signature).toContain('// Create item')
   })
 
-  it('preserves tool descriptions', () => {
+  it('formats search results with signatures', () => {
     const { entries } = generateToolCatalog(sampleTools)
-    const getUserEntry = entries.find(e => e.name === 'get_user')
+    const formatted = formatSearchResults(entries, '', entries.length)
 
-    expect(getUserEntry).toBeDefined()
-    expect(getUserEntry!.description).toBe('Get a user by ID')
-  })
-
-  it('includes method signatures', () => {
-    const { entries } = generateToolCatalog(sampleTools)
-    const createTodoEntry = entries.find(e => e.name === 'create_todo')
-
-    expect(createTodoEntry).toBeDefined()
-    expect(createTodoEntry!.signature).toContain('create_todo')
-    expect(createTodoEntry!.signature).toContain('Promise<unknown>')
-    expect(createTodoEntry!.signature).toContain('// Create a new todo item')
-  })
-})
-
-describe('searchToolCatalog', () => {
-  const { entries } = generateToolCatalog(sampleTools)
-
-  it('finds tools by name keyword', () => {
-    const results = searchToolCatalog(entries, 'user')
-    expect(results).toHaveLength(2)
-    expect(results.map(r => r.name)).toContain('get_user')
-    expect(results.map(r => r.name)).toContain('list_users')
-  })
-
-  it('finds tools by description keyword', () => {
-    const results = searchToolCatalog(entries, 'catalog')
-    expect(results).toHaveLength(1)
-    expect(results[0]!.name).toBe('search_products')
-  })
-
-  it('supports multi-word queries (AND logic)', () => {
-    const results = searchToolCatalog(entries, 'todo create')
-    expect(results).toHaveLength(1)
-    expect(results[0]!.name).toBe('create_todo')
-  })
-
-  it('returns all entries for empty query', () => {
-    const results = searchToolCatalog(entries, '')
-    expect(results).toHaveLength(5)
-  })
-
-  it('is case-insensitive', () => {
-    const results = searchToolCatalog(entries, 'USER')
-    expect(results).toHaveLength(2)
-  })
-
-  it('returns empty array for no matches', () => {
-    const results = searchToolCatalog(entries, 'nonexistent')
-    expect(results).toHaveLength(0)
-  })
-
-  it('ranks exact name matches highest', () => {
-    const tools = [
-      makeTool('user', 'A tool called user'),
-      makeTool('get-user', 'Get a user by ID'),
-      makeTool('manage-data', 'Manages user data'),
-    ]
-    const { entries: catalog } = generateToolCatalog(tools)
-    const results = searchToolCatalog(catalog, 'user')
-
-    expect(results[0]!.name).toBe('user')
-  })
-
-  it('ranks name-prefix matches before description matches', () => {
-    const tools = [
-      makeTool('data-handler', 'Handles user requests'),
-      makeTool('user-settings', 'Manage settings'),
-    ]
-    const { entries: catalog } = generateToolCatalog(tools)
-    const results = searchToolCatalog(catalog, 'user')
-
-    expect(results[0]!.name).toBe('user_settings')
-  })
-})
-
-describe('formatSearchResults', () => {
-  const { entries } = generateToolCatalog(sampleTools)
-
-  it('formats matching results with count', () => {
-    const matches = searchToolCatalog(entries, 'user')
-    const result = formatSearchResults(matches, 'user', entries.length)
-
-    expect(result).toContain('Found 2/5 tools matching "user"')
-    expect(result).toContain('codemode.')
-  })
-
-  it('formats no-match message with total count', () => {
-    const result = formatSearchResults([], 'nonexistent', entries.length)
-
-    expect(result).toContain('No tools found matching "nonexistent"')
-    expect(result).toContain('5 tools available')
-  })
-
-  it('shows "All N tools" header when returning everything', () => {
-    const result = formatSearchResults(entries, '', entries.length)
-
-    expect(result).toContain('All 5 tools:')
+    expect(formatted).toContain('All 4 tools:')
+    expect(formatted).toContain('codemode.get_user')
   })
 })
 
 describe('createCodemodeTools', () => {
   it('creates a single code tool in standard mode', () => {
-    const result = createCodemodeTools(sampleTools)
+    const [codeTool] = createCodemodeTools(sampleTools)
 
-    expect(result).toHaveLength(1)
-    expect(result[0]!.name).toBe('code')
-    expect(result[0]!.description).toContain('Available via the `codemode` object')
-    expect(result[0]!.description).toContain('get_user')
+    expect(codeTool!.name).toBe('code')
+    expect(codeTool!.description).toContain('declare const codemode')
   })
 
-  it('creates search + code tools in progressive mode', () => {
-    const result = createCodemodeTools(sampleTools, { progressive: true })
+  it('creates search plus code in progressive mode', () => {
+    const tools = createCodemodeTools(sampleTools, { progressive: true })
 
-    expect(result).toHaveLength(2)
-    expect(result[0]!.name).toBe('search')
-    expect(result[1]!.name).toBe('code')
+    expect(tools.map(tool => tool.name)).toEqual(['search', 'code'])
+    expect(tools[1]!.description).not.toContain('declare const codemode')
   })
 
-  it('does not embed type definitions in progressive code tool', () => {
-    const result = createCodemodeTools(sampleTools, { progressive: true })
-    const codeTool = result[1]!
+  it('omits the example block when many tools exist', () => {
+    const manyTools = Array.from({ length: 11 }, (_, index) =>
+      makeTool(`tool-${index + 1}`, `Tool ${index + 1}`, { id: z.string() }),
+    )
+    const [codeTool] = createCodemodeTools(manyTools)
 
-    expect(codeTool.description).toContain('5 tools are available')
-    expect(codeTool.description).toContain('search')
-    expect(codeTool.description).not.toContain('declare const codemode')
+    expect(codeTool!.description).not.toContain('Example:')
   })
 
-  it('embeds all type definitions in standard code tool', () => {
-    const result = createCodemodeTools(sampleTools)
-    const codeTool = result[0]!
+  it('adds outputSchema to the code tool', () => {
+    const [codeTool] = createCodemodeTools(sampleTools)
+    const outputSchema = codeTool!.outputSchema!
 
-    expect(codeTool.description).toContain('declare const codemode')
-    expect(codeTool.description).toContain('get_user')
-    expect(codeTool.description).toContain('list_users')
-    expect(codeTool.description).not.toContain('// Get a user by ID')
-  })
-
-  it('uses custom description template in standard mode', () => {
-    const result = createCodemodeTools(sampleTools, {
-      description: 'My tools ({{count}}): {{types}}',
-    })
-
-    expect(result[0]!.description).toContain('My tools (5)')
-    expect(result[0]!.description).toContain('declare const codemode')
-  })
-
-  it('uses custom description template in progressive mode', () => {
-    const result = createCodemodeTools(sampleTools, {
-      progressive: true,
-      description: 'Search first, then execute. {{count}} available.',
-    })
-
-    expect(result[1]!.description).toBe('Search first, then execute. 5 available.')
-  })
-
-  it('search tool has readOnlyHint annotation', () => {
-    const result = createCodemodeTools(sampleTools, { progressive: true })
-    const searchTool = result[0]!
-
-    expect(searchTool.annotations?.readOnlyHint).toBe(true)
-    expect(searchTool.annotations?.destructiveHint).toBe(false)
-  })
-
-  it('omits the example block when many tools are available in standard mode', () => {
-    const result = createCodemodeTools(manyTools)
-    const codeTool = result[0]!
-
-    expect(codeTool.description).toContain('declare const codemode')
-    expect(codeTool.description).not.toContain('Example:')
-    expect(codeTool.description).not.toContain('const data = await codemode.get_data')
-  })
-
-  it('omits the example block when many tools are available in progressive mode', () => {
-    const result = createCodemodeTools(manyTools, { progressive: true })
-    const codeTool = result[1]!
-
-    expect(codeTool.description).toContain('11 tools are available')
-    expect(codeTool.description).not.toContain('Example:')
-    expect(codeTool.description).not.toContain('const user = await codemode.get_user')
-  })
-
-  it('includes the example block when exactly at the threshold in standard mode', () => {
-    const result = createCodemodeTools(boundaryTools)
-    const codeTool = result[0]!
-
-    expect(codeTool.description).toContain('Example:')
-  })
-
-  it('includes the example block when exactly at the threshold in progressive mode', () => {
-    const result = createCodemodeTools(boundaryTools, { progressive: true })
-    const codeTool = result[1]!
-
-    expect(codeTool.description).toContain('Example:')
-  })
-
-  it('collapses triple newlines in description output', () => {
-    const result = createCodemodeTools(sampleTools, {
-      description: 'Line 1.\n\n\n\nLine 2. {{types}}',
-    })
-    const desc = result[0]!.description
-
-    expect(desc).not.toMatch(/\n{3,}/)
-    expect(desc).toContain('Line 1.\n\nLine 2.')
+    expect(outputSchema.ok).toBeDefined()
+    expect(outputSchema.result).toBeDefined()
+    expect(outputSchema.error).toBeDefined()
+    expect(outputSchema.logs).toBeDefined()
+    expect(outputSchema.durationMs).toBeDefined()
   })
 })
 
-describe('buildDispatchFunctions — structuredContent handling', () => {
-  it('returns structuredContent when present, not text content', async () => {
+describe('buildDispatchFunctions', () => {
+  it('prefers structuredContent over text content', async () => {
     const tools: McpToolDefinitionListItem[] = [{
       name: 'create-item',
-      description: 'Create an item',
+      description: 'Create item',
       inputSchema: { title: z.string() },
       handler: async () => ({
         structuredContent: { ok: true, data: { id: 'abc123' } },
         content: [{ type: 'text' as const, text: 'Created item successfully' }],
       }),
     }]
-    const [codeTool] = createCodemodeTools(tools)
-    const result = await codeTool!.handler!({ code: 'return await codemode.create_item({ title: "Test" })' }, mockMcpExtra())
-    const text = (result as { content: { text: string }[] }).content[0]!.text
-    const parsed = JSON.parse(text)
+    const { toolNameMap } = generateTypesFromTools(tools)
+    const fns = buildDispatchFunctions(tools, toolNameMap, mockMcpExtra())
 
-    expect(parsed).toEqual({ ok: true, data: { id: 'abc123' } })
+    await expect(fns.create_item!({ title: 'Test' })).resolves.toEqual({ ok: true, data: { id: 'abc123' } })
   })
 
-  it('preserves typed fields (booleans, nested objects) from structuredContent', async () => {
+  it('preserves plain text exactly instead of JSON parsing it', async () => {
     const tools: McpToolDefinitionListItem[] = [{
-      name: 'get-status',
-      description: 'Get status',
+      name: 'get-code',
+      description: 'Get code',
       inputSchema: {},
       handler: async () => ({
-        structuredContent: { active: true, count: 42, nested: { a: [1, 2] } },
-        content: [{ type: 'text' as const, text: 'Status OK' }],
+        content: [{ type: 'text' as const, text: '123' }],
       }),
     }]
-    const [codeTool] = createCodemodeTools(tools)
-    const result = await codeTool!.handler!({ code: 'return await codemode.get_status()' }, mockMcpExtra())
-    const text = (result as { content: { text: string }[] }).content[0]!.text
-    const parsed = JSON.parse(text)
+    const { toolNameMap } = generateTypesFromTools(tools)
+    const fns = buildDispatchFunctions(tools, toolNameMap, mockMcpExtra())
 
-    expect(parsed.active).toBe(true)
-    expect(parsed.count).toBe(42)
-    expect(parsed.nested).toEqual({ a: [1, 2] })
+    await expect(fns.get_code!({})).resolves.toBe('123')
   })
 
-  it('enables operation chaining with structuredContent IDs', async () => {
-    const tools: McpToolDefinitionListItem[] = [
-      {
-        name: 'create-item',
-        description: 'Create an item',
-        inputSchema: { title: z.string() },
-        handler: async () => ({
-          structuredContent: { ok: true, data: { id: 'xyz789' } },
-          content: [{ type: 'text' as const, text: 'Created' }],
-        }),
-      },
-      {
-        name: 'update-item',
-        description: 'Update an item',
-        inputSchema: { id: z.string(), title: z.string() },
-        handler: async (args: Record<string, unknown>) => ({
-          structuredContent: { ok: true, data: { id: args.id, title: args.title } },
-          content: [{ type: 'text' as const, text: `Updated ${args.id}` }],
-        }),
-      },
-    ]
-    const [codeTool] = createCodemodeTools(tools)
-    const result = await codeTool!.handler!({
-      code: `
-        const created = await codemode.create_item({ title: "Test" });
-        const updated = await codemode.update_item({ id: created.data.id, title: "Updated" });
-        return updated;
-      `,
-    }, mockMcpExtra())
-    const text = (result as { content: { text: string }[] }).content[0]!.text
-    const parsed = JSON.parse(text)
-
-    expect(parsed).toEqual({ ok: true, data: { id: 'xyz789', title: 'Updated' } })
-  })
-
-  it('falls back to text content when structuredContent is absent', async () => {
+  it('preserves native plain object returns', async () => {
     const tools: McpToolDefinitionListItem[] = [{
-      name: 'echo',
-      description: 'Echo text',
-      inputSchema: { msg: z.string() },
-      handler: async (args: Record<string, unknown>) => ({
-        content: [{ type: 'text' as const, text: args.msg as string }],
-      }),
-    }]
-    const [codeTool] = createCodemodeTools(tools)
-    const result = await codeTool!.handler!({ code: 'return await codemode.echo({ msg: "hello" })' }, mockMcpExtra())
-    const text = (result as { content: { text: string }[] }).content[0]!.text
-
-    expect(text).toBe('hello')
-  })
-
-  it('handles structuredContent-only result (no content array)', async () => {
-    const tools: McpToolDefinitionListItem[] = [{
-      name: 'data-only',
-      description: 'Data only tool',
+      name: 'workspace-overview',
+      description: 'Workspace overview',
       inputSchema: {},
-      handler: async () => ({
-        structuredContent: { value: 99 },
+      handler: async () => ({ ok: true, data: { total: 3 } }),
+    }]
+    const { toolNameMap } = generateTypesFromTools(tools)
+    const fns = buildDispatchFunctions(tools, toolNameMap, mockMcpExtra())
+
+    await expect(fns.workspace_overview!({})).resolves.toEqual({ ok: true, data: { total: 3 } })
+  })
+
+  it('normalizes thrown errors into tool-error sentinels', async () => {
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'delete-item',
+      description: 'Delete item',
+      inputSchema: { id: z.string() },
+      handler: async () => {
+        throw new Error('Item not found')
+      },
+    }]
+    const { toolNameMap } = generateTypesFromTools(tools)
+    const fns = buildDispatchFunctions(tools, toolNameMap, mockMcpExtra())
+
+    await expect(fns.delete_item!({ id: 'missing' })).resolves.toEqual({
+      __toolError: true,
+      message: 'Item not found',
+      tool: 'delete_item',
+      details: undefined,
+    })
+  })
+
+  it('passes the real MCP extra into inner tool handlers', async () => {
+    const extra = mockMcpExtra()
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'inspect-extra',
+      description: 'Inspect extra',
+      inputSchema: { id: z.string() },
+      handler: async (_args, receivedExtra) => ({
+        requestId: receivedExtra.requestId,
+        sameSignal: receivedExtra.signal === extra.signal,
+      }),
+    }]
+    const { toolNameMap } = generateTypesFromTools(tools)
+    const fns = buildDispatchFunctions(tools, toolNameMap, extra)
+
+    await expect(fns.inspect_extra!({ id: '1' })).resolves.toEqual({
+      requestId: 1,
+      sameSignal: true,
+    })
+  })
+})
+
+describe('code tool envelope', () => {
+  it('returns structured success envelopes', async () => {
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'get-user',
+      description: 'Get user',
+      inputSchema: { id: z.string() },
+      handler: async (args: { id: string }) => ({
+        id: args.id,
+        active: true,
       }),
     }]
     const [codeTool] = createCodemodeTools(tools)
-    const result = await codeTool!.handler!({ code: 'return await codemode.data_only()' }, mockMcpExtra())
-    const text = (result as { content: { text: string }[] }).content[0]!.text
-    const parsed = JSON.parse(text)
+    const result = await codeTool!.handler!({ code: 'return await codemode.get_user({ id: "u1" })' }, mockMcpExtra()) as {
+      isError?: boolean
+      structuredContent?: unknown
+    }
 
-    expect(parsed).toEqual({ value: 99 })
+    expect(result.isError).toBe(false)
+    expect(result.structuredContent).toEqual({
+      ok: true,
+      result: { id: 'u1', active: true },
+      durationMs: expect.any(Number),
+    })
+  })
+
+  it('returns structured error envelopes', async () => {
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'delete-item',
+      description: 'Delete item',
+      inputSchema: { id: z.string() },
+      handler: async () => {
+        throw new Error('Item not found')
+      },
+    }]
+    const [codeTool] = createCodemodeTools(tools)
+    const result = await codeTool!.handler!({ code: 'return await codemode.delete_item({ id: "missing" })' }, mockMcpExtra()) as {
+      isError?: boolean
+      structuredContent?: unknown
+    }
+
+    expect(result.isError).toBe(true)
+    expect(result.structuredContent).toEqual({
+      ok: false,
+      error: 'Item not found',
+      durationMs: expect.any(Number),
+    })
   })
 })
 
 describe('normalizeCode', () => {
-  it('strips markdown fences', () => {
-    const code = '```javascript\nconst x = 1;\n```'
-    expect(normalizeCode(code)).toBe('const x = 1;')
-  })
-
-  it('unwraps async arrow function with block body', () => {
-    const code = 'async () => {\n  return 42;\n}'
-    expect(normalizeCode(code)).toBe('return 42;')
-  })
-
-  it('unwraps async arrow function with expression body', () => {
-    const code = 'async () => codemode.get_user({ id: "1" })'
-    expect(normalizeCode(code)).toBe('return codemode.get_user({ id: "1" });')
-  })
-
-  it('unwraps IIFE pattern', () => {
-    const code = '(async () => {\n  const x = 1;\n  return x;\n})()'
-    expect(normalizeCode(code)).toBe('const x = 1;\n  return x;')
-  })
-
-  it('unwraps named function + call pattern', () => {
-    const code = 'async function main() {\n  return 42;\n}\nmain()'
-    expect(normalizeCode(code)).toBe('return 42;')
-  })
-
-  it('strips export default prefix', () => {
-    const code = 'export default async () => {\n  return 1;\n}'
-    expect(normalizeCode(code)).toBe('return 1;')
-  })
-
-  it('passes through plain code unchanged', () => {
-    const code = 'const result = await codemode.list_users();\nreturn result;'
-    expect(normalizeCode(code)).toBe(code)
-  })
-})
-
-describe('buildDispatchFunctions — error handling', () => {
-  it('returns __toolError sentinel for isError results', async () => {
-    const tool: McpToolDefinition = {
-      name: 'fail-tool',
-      description: 'A tool that fails',
-      inputSchema: { id: z.string() },
-      handler: async () => ({
-        isError: true,
-        content: [{ type: 'text' as const, text: 'Item not found' }],
-      }),
-    }
-    const { toolNameMap } = generateTypesFromTools([tool])
-    const fns = buildDispatchFunctions([tool], toolNameMap)
-    const result = await fns.fail_tool!({ id: 'nonexistent' }) as Record<string, unknown>
-
-    expect(result.__toolError).toBe(true)
-    expect(result.message).toBe('Item not found')
-    expect(result.tool).toBe('fail_tool')
-  })
-
-  it('includes structuredContent as details in error sentinel', async () => {
-    const tool: McpToolDefinition = {
-      name: 'validate-tool',
-      description: 'A validation tool',
-      inputSchema: { id: z.string() },
-      handler: async () => ({
-        isError: true,
-        structuredContent: { ok: false, error: { category: 'validation', retryable: false } },
-        content: [{ type: 'text' as const, text: 'Validation failed' }],
-      }),
-    }
-    const { toolNameMap } = generateTypesFromTools([tool])
-    const fns = buildDispatchFunctions([tool], toolNameMap)
-    const result = await fns.validate_tool!({ id: 'bad' }) as Record<string, unknown>
-
-    expect(result.__toolError).toBe(true)
-    expect(result.message).toBe('Validation failed')
-    expect(result.details).toEqual({ ok: false, error: { category: 'validation', retryable: false } })
-  })
-
-  it('error sentinel has no details when no structuredContent', async () => {
-    const tool: McpToolDefinition = {
-      name: 'simple-fail',
-      description: 'Simple failure',
-      inputSchema: {},
-      handler: async () => ({
-        isError: true,
-        content: [{ type: 'text' as const, text: 'Something went wrong' }],
-      }),
-    }
-    const { toolNameMap } = generateTypesFromTools([tool])
-    const fns = buildDispatchFunctions([tool], toolNameMap)
-    const result = await fns.simple_fail!({}) as Record<string, unknown>
-
-    expect(result.__toolError).toBe(true)
-    expect(result.message).toBe('Something went wrong')
-    expect(result.details).toBeUndefined()
-  })
-
-  it('non-error results are unaffected by error handling', async () => {
-    const tool: McpToolDefinition = {
-      name: 'ok-tool',
-      description: 'A tool that succeeds',
-      inputSchema: {},
-      handler: async () => ({
-        content: [{ type: 'text' as const, text: '{"status":"ok"}' }],
-      }),
-    }
-    const { toolNameMap } = generateTypesFromTools([tool])
-    const fns = buildDispatchFunctions([tool], toolNameMap)
-    const result = await fns.ok_tool!({})
-
-    expect(result).toEqual({ status: 'ok' })
-  })
-
-  it('isError with structuredContent prioritizes error over structured data', async () => {
-    const tool: McpToolDefinition = {
-      name: 'error-with-data',
-      description: 'Error with data',
-      inputSchema: {},
-      handler: async () => ({
-        isError: true,
-        structuredContent: { field: 'id', expected: 'valid ObjectId' },
-        content: [{ type: 'text' as const, text: 'Invalid ID format' }],
-      }),
-    }
-    const { toolNameMap } = generateTypesFromTools([tool])
-    const fns = buildDispatchFunctions([tool], toolNameMap)
-    const result = await fns.error_with_data!({}) as Record<string, unknown>
-
-    // Should be an error, not the structuredContent
-    expect(result.__toolError).toBe(true)
-    expect(result.message).toBe('Invalid ID format')
-    expect(result.details).toEqual({ field: 'id', expected: 'valid ObjectId' })
+  it('normalizes common wrapper formats', () => {
+    expect(normalizeCode('```javascript\nconst x = 1;\n```')).toBe('const x = 1;')
+    expect(normalizeCode('async () => codemode.get_user({ id: "1" })')).toBe('return codemode.get_user({ id: "1" });')
+    expect(normalizeCode('export default async () => {\n  return 1;\n}')).toBe('return 1;')
   })
 })
 
 describe('disposeCodeMode', () => {
   it('is exported and callable', () => {
-    expect(typeof disposeCodeMode).toBe('function')
     expect(() => disposeCodeMode()).not.toThrow()
   })
 })

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -60,6 +60,14 @@ const sampleTools = [
   }),
 ]
 
+const manyTools = Array.from({ length: 11 }, (_, i) =>
+  makeTool(`tool-${i + 1}`, `Tool ${i + 1}`, { id: z.string() }),
+)
+
+const boundaryTools = Array.from({ length: 10 }, (_, i) =>
+  makeTool(`tool-${i + 1}`, `Tool ${i + 1}`, { id: z.string() }),
+)
+
 describe('sanitizeToolName', () => {
   it('replaces hyphens with underscores', () => {
     expect(sanitizeToolName('get-user')).toBe('get_user')
@@ -96,6 +104,13 @@ describe('generateTypesFromTools', () => {
 
     expect(toolNameMap.get('delete_todo')).toBe('delete-todo')
     expect(toolNameMap.get('search_products')).toBe('search-products')
+  })
+
+  it('omits description comments from the embedded type block', () => {
+    const { typeDefinitions } = generateTypesFromTools(sampleTools)
+
+    expect(typeDefinitions).toContain('get_user')
+    expect(typeDefinitions).not.toContain('// Get a user by ID')
   })
 })
 
@@ -165,6 +180,7 @@ describe('generateToolCatalog', () => {
     expect(createTodoEntry).toBeDefined()
     expect(createTodoEntry!.signature).toContain('create_todo')
     expect(createTodoEntry!.signature).toContain('Promise<unknown>')
+    expect(createTodoEntry!.signature).toContain('// Create a new todo item')
   })
 })
 
@@ -260,7 +276,7 @@ describe('createCodemodeTools', () => {
 
     expect(result).toHaveLength(1)
     expect(result[0]!.name).toBe('code')
-    expect(result[0]!.description).toContain('Available tools via')
+    expect(result[0]!.description).toContain('Available via the `codemode` object')
     expect(result[0]!.description).toContain('get_user')
   })
 
@@ -276,7 +292,7 @@ describe('createCodemodeTools', () => {
     const result = createCodemodeTools(sampleTools, { progressive: true })
     const codeTool = result[1]!
 
-    expect(codeTool.description).toContain('5 tools available')
+    expect(codeTool.description).toContain('5 tools are available')
     expect(codeTool.description).toContain('search')
     expect(codeTool.description).not.toContain('declare const codemode')
   })
@@ -288,6 +304,7 @@ describe('createCodemodeTools', () => {
     expect(codeTool.description).toContain('declare const codemode')
     expect(codeTool.description).toContain('get_user')
     expect(codeTool.description).toContain('list_users')
+    expect(codeTool.description).not.toContain('// Get a user by ID')
   })
 
   it('uses custom description template in standard mode', () => {
@@ -314,6 +331,48 @@ describe('createCodemodeTools', () => {
 
     expect(searchTool.annotations?.readOnlyHint).toBe(true)
     expect(searchTool.annotations?.destructiveHint).toBe(false)
+  })
+
+  it('omits the example block when many tools are available in standard mode', () => {
+    const result = createCodemodeTools(manyTools)
+    const codeTool = result[0]!
+
+    expect(codeTool.description).toContain('declare const codemode')
+    expect(codeTool.description).not.toContain('Example:')
+    expect(codeTool.description).not.toContain('const data = await codemode.get_data')
+  })
+
+  it('omits the example block when many tools are available in progressive mode', () => {
+    const result = createCodemodeTools(manyTools, { progressive: true })
+    const codeTool = result[1]!
+
+    expect(codeTool.description).toContain('11 tools are available')
+    expect(codeTool.description).not.toContain('Example:')
+    expect(codeTool.description).not.toContain('const user = await codemode.get_user')
+  })
+
+  it('includes the example block when exactly at the threshold in standard mode', () => {
+    const result = createCodemodeTools(boundaryTools)
+    const codeTool = result[0]!
+
+    expect(codeTool.description).toContain('Example:')
+  })
+
+  it('includes the example block when exactly at the threshold in progressive mode', () => {
+    const result = createCodemodeTools(boundaryTools, { progressive: true })
+    const codeTool = result[1]!
+
+    expect(codeTool.description).toContain('Example:')
+  })
+
+  it('collapses triple newlines in description output', () => {
+    const result = createCodemodeTools(sampleTools, {
+      description: 'Line 1.\n\n\n\nLine 2. {{types}}',
+    })
+    const desc = result[0]!.description
+
+    expect(desc).not.toMatch(/\n{3,}/)
+    expect(desc).toContain('Line 1.\n\nLine 2.')
   })
 })
 

--- a/packages/nuxt-mcp-toolkit/test/codemode.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/codemode.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../src/runtime/server/mcp/codemode/types'
 import { buildDispatchFunctions, createCodemodeTools, disposeCodeMode } from '../src/runtime/server/mcp/codemode/index'
 import { normalizeCode } from '../src/runtime/server/mcp/codemode/executor'
+import { isCallToolResult } from '../src/runtime/server/mcp/definitions/results'
 import type { McpRequestExtra } from '../src/runtime/server/mcp/definitions/sdk-extra'
 import type { McpToolDefinition, McpToolDefinitionListItem } from '../src/runtime/server/mcp/definitions/tools'
 
@@ -222,7 +223,7 @@ describe('buildDispatchFunctions', () => {
     const fns = buildDispatchFunctions(tools, toolNameMap, mockMcpExtra())
 
     await expect(fns.delete_item!({ id: 'missing' })).resolves.toEqual({
-      __toolError: true,
+      __mcp_toolkit_error__: true,
       message: 'Item not found',
       tool: 'delete_item',
       details: undefined,
@@ -310,5 +311,71 @@ describe('normalizeCode', () => {
 describe('disposeCodeMode', () => {
   it('is exported and callable', () => {
     expect(() => disposeCodeMode()).not.toThrow()
+  })
+})
+
+describe('isCallToolResult', () => {
+  it('matches objects with content array', () => {
+    expect(isCallToolResult({ content: [{ type: 'text', text: 'hi' }] })).toBe(true)
+  })
+
+  it('matches objects with structuredContent', () => {
+    expect(isCallToolResult({ structuredContent: { data: 1 } })).toBe(true)
+  })
+
+  it('matches objects with boolean isError', () => {
+    expect(isCallToolResult({ isError: true })).toBe(true)
+    expect(isCallToolResult({ isError: false })).toBe(true)
+  })
+
+  it('rejects objects with non-boolean isError', () => {
+    expect(isCallToolResult({ isError: 'yes' })).toBe(false)
+    expect(isCallToolResult({ isError: 0 })).toBe(false)
+  })
+
+  it('rejects plain objects with incidental properties', () => {
+    expect(isCallToolResult({ content: 'not-an-array' })).toBe(false)
+    expect(isCallToolResult({ ok: true, data: 123 })).toBe(false)
+  })
+})
+
+describe('enum escaping in type generation', () => {
+  it('escapes special characters in enum values', () => {
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'get-quote',
+      description: 'Get a quote',
+      inputSchema: {
+        style: z.enum(['he said "hello"', "it's fine", 'back\\slash']),
+      },
+      handler: async () => 'ok',
+    }]
+    const { typeDefinitions } = generateTypesFromTools(tools)
+
+    expect(typeDefinitions).toContain('"he said \\"hello\\""')
+    expect(typeDefinitions).toContain('"it\'s fine"')
+    expect(typeDefinitions).toContain('"back\\\\slash"')
+  })
+})
+
+describe('buildDispatchFunctions error handling', () => {
+  it('normalizes isError CallToolResult into tool-error sentinel', async () => {
+    const tools: McpToolDefinitionListItem[] = [{
+      name: 'fail-tool',
+      description: 'Fails with isError',
+      inputSchema: {},
+      handler: async () => ({
+        isError: true,
+        content: [{ type: 'text' as const, text: 'Permission denied' }],
+      }),
+    }]
+    const { toolNameMap } = generateTypesFromTools(tools)
+    const fns = buildDispatchFunctions(tools, toolNameMap, mockMcpExtra())
+
+    await expect(fns.fail_tool!({})).resolves.toEqual({
+      __mcp_toolkit_error__: true,
+      message: 'Permission denied',
+      tool: 'fail_tool',
+      details: undefined,
+    })
   })
 })

--- a/work.md
+++ b/work.md
@@ -1,0 +1,291 @@
+# Code Mode Integration — Combined Changeset
+
+> Branch: `codex/codemode-integration`
+> Base: `0bb110a` (main at time of fork)
+> Files changed: 12 (+1,484 / -516 lines)
+
+This document describes every change in this branch, why it was made, and how it was validated. The goal is a single consolidated PR that the module author can review with full context instead of piecemeal PRs.
+
+---
+
+## Table of Contents
+
+1. [Per-Session RPC Architecture](#1-per-session-rpc-architecture)
+2. [AsyncLocalStorage Context Preservation](#2-asynclocalstorage-context-preservation)
+3. [Resource Limits & Abuse Prevention](#3-resource-limits--abuse-prevention)
+4. [structuredContent Dispatch](#4-structuredcontent-dispatch)
+5. [Tool Error Surfacing in Sandbox](#5-tool-error-surfacing-in-sandbox)
+6. [Typed Output Schemas](#6-typed-output-schemas)
+7. [Type Generation Improvements](#7-type-generation-improvements)
+8. [Description Templates & Progressive Mode](#8-description-templates--progressive-mode)
+9. [Structured Envelope Responses](#9-structured-envelope-responses)
+10. [Handler Reuse Between Registration and Code Mode](#10-handler-reuse-between-registration-and-code-mode)
+11. [Hardening Pass (PR Review Fixes)](#11-hardening-pass-pr-review-fixes)
+12. [Test Coverage](#12-test-coverage)
+13. [Documentation Updates](#13-documentation-updates)
+
+---
+
+## 1. Per-Session RPC Architecture
+
+**Problem:** The original executor used a singleton RPC server and a singleton V8 runtime. All concurrent `execute()` calls shared the same `fns` map, `onReturn` callback, and RPC token. This meant:
+- Concurrent executions could overwrite each other's dispatch functions
+- A sandbox from execution A could call tools meant for execution B
+- The `onReturn` callback was a single slot — racing executions would lose return values
+
+**Solution:** Each `execute()` call now creates its own isolated RPC session:
+- Fresh `createServer()` on port 0 (OS-assigned ephemeral port)
+- Unique `execId` (8 random bytes) and `token` (32 random bytes) per execution
+- `ExecutionContext` struct holds per-execution state: `fns`, `onReturn`, `deadlineMs`, `rpcCallCount`
+- The `fns` map is frozen with `Object.freeze()` so sandbox code can't mutate it
+- The sandbox sends `execId` in every RPC call; the server validates it matches the session
+- `ActiveSession` tracking with cleanup on completion, error, or timeout
+
+**Files:** `executor.ts` (complete rewrite of RPC layer)
+
+---
+
+## 2. AsyncLocalStorage Context Preservation
+
+**Problem:** Nitro uses `AsyncLocalStorage` to carry per-request context (H3 event, auth, etc.). When Code Mode dispatches a tool call via HTTP RPC, the async context is lost — the RPC handler runs in the HTTP server's context, not the original request's.
+
+**Solution:** On entry to `execute()`, we capture the current async context via `AsyncLocalStorage.snapshot()`. Every tool dispatch is wrapped through `restoreContext()`, which re-enters the original request's async context before calling the tool handler. This means tools called from sandbox code have access to the same `useEvent()`, auth state, etc. as if called directly.
+
+A runtime check rejects Node.js < 18.16.0 where `snapshot()` is unavailable, returning a clear error message instead of crashing.
+
+**Files:** `executor.ts` (lines 386-395, 437-448, 198, 216)
+
+---
+
+## 3. Resource Limits & Abuse Prevention
+
+**Problem:** The original executor had no protection against:
+- Oversized RPC request bodies (memory exhaustion)
+- Infinite tool call loops
+- Runaway wall-clock time (sandbox waiting forever on slow tools)
+- Oversized tool responses
+
+**Solution:** Added configurable limits with sensible defaults:
+
+| Limit | Default | Config Key | Enforcement |
+|-------|---------|------------|-------------|
+| RPC request body | 1 MB | `maxRequestBodyBytes` | HTTP 413, streaming byte count |
+| Tool calls per execution | 200 | `maxToolCalls` | HTTP 429, counter on `ExecutionContext` |
+| Wall-clock timeout | 60s | `wallTimeLimitMs` | `setTimeout` → `runtime.dispose()` |
+| Tool response size | 1 MB | `maxToolResponseSize` | Truncation (same strategy as `maxResultSize`) |
+
+The wall-clock timeout is separate from the V8 CPU time limit. CPU time only counts isolate execution; wall time caps total elapsed time including host-side tool calls. On timeout, the runtime is forcefully disposed and the sandbox gets a clear error.
+
+Error messages returned to sandbox/client are sanitized: file paths are replaced with `[path]`, stack traces are stripped, and messages are truncated to 500 chars. Full errors are logged server-side with `console.error('[nuxt-mcp-toolkit] ...')`.
+
+**Files:** `executor.ts`, `types.ts` (new options), `8.code-mode.md` (docs)
+
+---
+
+## 4. structuredContent Dispatch
+
+**Problem:** When a tool handler returned `structuredContent` (the MCP spec's typed data channel), Code Mode ignored it and fell through to extracting text from `content[].text`. This silently lost IDs, booleans, nested objects — breaking operation chaining where a returned ID is needed for follow-up calls.
+
+**Solution:** `normalizeDispatchResult()` now checks `structuredContent` first:
+1. If `rawResult.structuredContent != null` → return it directly (preserves typed data)
+2. If `rawResult.isError` → convert to `CodeModeToolError` sentinel (see #5)
+3. If `rawResult.content` has text items → return joined text (no JSON.parse — intentional, avoids ambiguity)
+4. Plain objects/primitives pass through unchanged
+
+The function also uses `isCallToolResult()` to distinguish MCP results from plain objects returned by handlers. This duck-type check was tightened: `isError` alone no longer matches unless it's a boolean (prevents false positives from objects that happen to have an `isError` property).
+
+**Files:** `index.ts` (normalizeDispatchResult, extractTextContent), `results.ts` (isCallToolResult)
+
+---
+
+## 5. Tool Error Surfacing in Sandbox
+
+**Problem:** Tool errors (`isError: true` results or thrown exceptions) were returned as plain strings to sandbox code, making them indistinguishable from successful results. `try/catch` never fired, and structured error details from `structuredContent` were lost.
+
+**Solution:** Tool errors are now wrapped as a sentinel object with a namespaced key:
+
+```ts
+{
+  __mcp_toolkit_error__: true,
+  message: "Permission denied",
+  tool: "delete_item",
+  details: { /* structuredContent if available */ }
+}
+```
+
+The sandbox proxy code detects this sentinel and throws a structured `Error` with `.tool`, `.isToolError`, and `.details` properties. This lets sandbox code use `try/catch` to handle tool errors with full context.
+
+The sentinel key is namespaced (`__mcp_toolkit_error__`) rather than generic (`__toolError`) to avoid collisions with legitimate tool return values. Similarly, the stderr error prefix is `__MCP_EXEC_ERR__` rather than `__ERROR__`.
+
+**Files:** `index.ts` (toToolError, CodeModeToolError), `executor.ts` (proxy boilerplate)
+
+---
+
+## 6. Typed Output Schemas
+
+**Problem:** All Code Mode tools returned `Promise<unknown>` regardless of whether an `outputSchema` was defined. The LLM had no type information about what to expect back.
+
+**Solution:** When a tool definition includes `outputSchema`, the type generator now emits typed return values:
+- Small schemas (<=3 primitive fields) are inlined: `Promise<{ id: string; ok: boolean }>`
+- Larger schemas get named interfaces: `Promise<GetReportOutput>`
+
+This reuses the same `generateSchemaTypeInfo()` helper used for input schemas, extracted from the duplicated inline logic.
+
+**Files:** `types.ts` (generateSchemaTypeInfo, generateToolTypeInfo output handling)
+
+---
+
+## 7. Type Generation Improvements
+
+Several improvements to the TypeScript type generation for sandbox code:
+
+- **Property key escaping:** Keys with special characters or reserved words are now properly quoted using `JSON.stringify()` via `formatTsPropertyKey()`. Before: `my-key?: string` (invalid TS). After: `"my-key"?: string`.
+- **Enum value escaping:** Enum strings containing quotes or backslashes are now escaped with `JSON.stringify(v)` instead of template literals. Before: `"he said "hello""` (broken). After: `"he said \"hello\""`.
+- **Name collision detection:** `buildToolNameMap()` now throws if two tools sanitize to the same name (e.g., `get-user` and `get_user` both become `get_user`), instead of silently overwriting.
+- **Description stripping:** `declare const codemode` block no longer includes `// description` comments inline, keeping the type block clean. Descriptions remain in catalog signatures for progressive mode.
+
+**Files:** `types.ts`
+
+---
+
+## 8. Description Templates & Progressive Mode
+
+**Problem:** The code tool descriptions were overly verbose with multi-paragraph instructions about combining sequential/parallel/conditional logic. This wastes context window for every tool call.
+
+**Solution:**
+- Simplified templates to essential information: what the tool does, how to write code, available types
+- Added `{{example}}` placeholder support alongside existing `{{types}}` and `{{count}}`
+- Example blocks are automatically omitted when there are >10 tools (they become noise at that scale)
+- Collapsed excessive newlines in template output
+- Progressive mode gets its own concise example showing the search→code workflow
+
+**Files:** `index.ts` (templates, applyDescriptionTemplate), `types.ts` (CodeModeOptions.description docs)
+
+---
+
+## 9. Structured Envelope Responses
+
+**Problem:** The code tool returned only text content — no structured data for programmatic consumption by MCP clients.
+
+**Solution:** The code tool now returns both `structuredContent` and `content`:
+
+```ts
+{
+  isError: false,
+  structuredContent: {
+    ok: true,
+    result: { id: "abc123" },
+    durationMs: 142,
+    logs: ["[stdout] Processing..."]
+  },
+  content: [{ type: "text", text: "..." }]  // human-readable fallback
+}
+```
+
+- `CodeToolEnvelope` is a discriminated union (`ok: true | false`) preventing impossible states (simultaneous result + error)
+- `ExecuteResult` is also a discriminated union — `result` and `error` are mutually exclusive at the type level
+- `durationMs` tracks wall-clock execution time
+- `outputSchema` is declared on the code tool definition so MCP clients can validate responses
+
+**Files:** `index.ts` (CodeToolEnvelope, createCodeToolEnvelope, formatSuccessContent), `types.ts` (ExecuteResult)
+
+---
+
+## 10. Handler Reuse Between Registration and Code Mode
+
+**Problem:** Code Mode reimplemented tool handler invocation: it manually resolved tool names, manually checked for `inputSchema`, and called handlers differently than `registerToolFromDefinition()`. This meant cache wrappers, error normalization, and future middleware would only apply to registered tools, not code mode dispatches.
+
+**Solution:** Extracted shared utilities from `registerToolFromDefinition()`:
+- `resolveToolDefinitionName(tool)` — applies `enrichNameTitle` to get the canonical name
+- `createWrappedToolHandler(tool)` — applies cache wrappers and returns the handler
+- `invokeWrappedToolHandler(tool, handler, input, extra)` — calls the handler with the correct argument shape (input+extra vs. extra-only based on whether `inputSchema` exists)
+
+Code Mode now uses these same functions, so cache, auth, and any future middleware apply consistently whether a tool is called via MCP protocol or via sandbox code.
+
+The `buildDispatchFunctions()` helper is now exported (used by tests) and accepts `McpRequestExtra`, which gets passed through to tool handlers so they have access to `requestId`, `signal`, `sendNotification`, etc.
+
+**Files:** `tools.ts` (resolveToolDefinitionName, createWrappedToolHandler, invokeWrappedToolHandler), `index.ts` (buildDispatchEntries, buildDispatchFunctionsFromEntries)
+
+---
+
+## 11. Hardening Pass (PR Review Fixes)
+
+After the feature work, a comprehensive PR review identified issues that were fixed:
+
+### Error sentinel spoofability
+Changed sentinel key from `__toolError` to `__mcp_toolkit_error__` and stderr prefix from `__ERROR__` to `__MCP_EXEC_ERR__` to avoid collisions with legitimate tool return values or user code logging.
+
+### Empty catch blocks
+Four truly empty `catch {}` blocks in cleanup paths (server.close, runtime.dispose, wall-timer dispose) now log warnings with `console.warn('[nuxt-mcp-toolkit] ...')` and context about which operation failed.
+
+### Unhandled promise rejection
+`void handleRpcRequest(...)` had no catch handler. If the inner try/catch failed AND `sendJson` also threw, the rejection escaped. Added `.catch(() => { if (!res.headersSent) res.destroy() })` as a safety net.
+
+### Missing server-side error logging
+The outer `catch` in `execute()` sanitized errors before returning them but never logged the raw error. Added `console.error('[nuxt-mcp-toolkit] Execution error:', error)` before sanitization so infrastructure errors are visible in server logs.
+
+### isCallToolResult false positives
+`isError` alone was enough to match `isCallToolResult()`. Now requires `typeof isError === 'boolean'` — objects with incidental string/number `isError` properties aren't misrouted.
+
+### Dead proxy cache
+`cachedProxyKey`/`cachedProxyCode` module-level variables never hit because each execution creates a new port+token. Removed entirely.
+
+### Impossible type states
+`ExecuteResult` was `{ result: unknown, error?: string }` — both could be set. Now a discriminated union where `result` and `error` are mutually exclusive. Same for `CodeToolEnvelope` with `ok` as discriminant.
+
+### disposeCodeMode error swallowing
+`.catch(() => {})` replaced with `.catch(error => console.warn(...))`.
+
+**Files:** `executor.ts`, `index.ts`, `types.ts`, `results.ts`
+
+---
+
+## 12. Test Coverage
+
+### codemode.test.ts (was ~180 lines, now ~380 lines)
+- Type generation: declarations, output types, name collision detection
+- Tool catalog: signatures, search formatting
+- `createCodemodeTools`: standard mode, progressive mode, example block omission, outputSchema
+- `buildDispatchFunctions`: structuredContent preference, plain text preservation, native object passthrough, thrown error → sentinel conversion, MCP extra propagation
+- Code tool envelope: structured success/error responses
+- `normalizeCode`: markdown fence stripping, arrow function unwrapping, export default removal
+- `isCallToolResult`: content arrays, structuredContent, boolean isError, non-boolean isError rejection, plain object rejection
+- Enum escaping: quotes, backslashes in enum values
+- `isError` CallToolResult → tool error sentinel flow
+
+### codemode-executor.test.ts (new, ~400 lines)
+- Concurrency: parallel executions with no cross-talk
+- RPC token validation: wrong token → 403
+- Execution ID validation: wrong execId → 400
+- Request body limits: oversized payload → 413
+- Tool call quota: exceeding maxToolCalls → 429
+- Tool response truncation: arrays, objects, primitives
+- Wall-clock timeout behavior
+- Cleanup verification after success/error/timeout
+
+---
+
+## 13. Documentation Updates
+
+- `8.code-mode.md`: Added new config options (`maxRequestBodyBytes`, `maxToolResponseSize`, `wallTimeLimitMs`, `maxToolCalls`) to the configuration reference and resource limits table. Added "Error Sanitization" section. Added Node.js >=18.16.0 callout.
+- `handlers.ts`: Expanded `experimental_codeMode` JSDoc with config keys and Node.js requirement.
+- `2.installation.md`: Minor addition (context for secure-exec requirement).
+
+---
+
+## Files Changed Summary
+
+| File | What changed |
+|------|-------------|
+| `executor.ts` | Rewritten: per-session RPC, AsyncLocalStorage, resource limits, error handling |
+| `index.ts` | Rewritten: structuredContent dispatch, tool error sentinels, envelope responses, handler reuse |
+| `types.ts` | Extended: output schemas, property key escaping, enum escaping, discriminated unions, new options |
+| `results.ts` | Exported `isCallToolResult`, tightened `isError` check |
+| `tools.ts` | Extracted `resolveToolDefinitionName`, `createWrappedToolHandler`, `invokeWrappedToolHandler` |
+| `handlers.ts` | JSDoc update for `experimental_codeMode` |
+| `executor.cloudflare.ts` | Re-export alignment |
+| `codemode.test.ts` | Expanded from ~180 to ~380 lines |
+| `codemode-executor.test.ts` | New: ~400 lines of executor integration tests |
+| `8.code-mode.md` | New config options, resource limits table, error sanitization section |
+| `2.installation.md` | Minor addition |
+| `5.handlers.md` | Minor addition |


### PR DESCRIPTION
# Code Mode Integration — Combined Changeset

This PR combines the earlier PRs (#210 #206 #207 #208 )into one branch, with a few additional improvements. The goal is to make review easier and give us a single discussion baseline; it is not intended to be merge-ready yet.

This document describes every change in this branch, why it was made, and how it was validated.

---

## Table of Contents

1. [Per-Session RPC Architecture](#1-per-session-rpc-architecture)
2. [AsyncLocalStorage Context Preservation](#2-asynclocalstorage-context-preservation)
3. [Resource Limits & Abuse Prevention](#3-resource-limits--abuse-prevention)
4. [structuredContent Dispatch](#4-structuredcontent-dispatch)
5. [Tool Error Surfacing in Sandbox](#5-tool-error-surfacing-in-sandbox)
6. [Typed Output Schemas](#6-typed-output-schemas)
7. [Type Generation Improvements](#7-type-generation-improvements)
8. [Description Templates & Progressive Mode](#8-description-templates--progressive-mode)
9. [Structured Envelope Responses](#9-structured-envelope-responses)
10. [Handler Reuse Between Registration and Code Mode](#10-handler-reuse-between-registration-and-code-mode)
11. [Hardening Pass (PR Review Fixes)](#11-hardening-pass-pr-review-fixes)
12. [**Per-Tool Code Mode Overrides & Smart Progressive**](#12-per-tool-code-mode-overrides--smart-progressive)
13. [Test Coverage](#13-test-coverage)
14. [Documentation Updates](#14-documentation-updates)

---

## 1. Per-Session RPC Architecture

**Problem:** The original executor used a singleton RPC server and a singleton V8 runtime. All concurrent `execute()` calls shared the same `fns` map, `onReturn` callback, and RPC token. This meant:
- Concurrent executions could overwrite each other's dispatch functions
- A sandbox from execution A could call tools meant for execution B
- The `onReturn` callback was a single slot — racing executions would lose return values

**Solution:** Each `execute()` call now creates its own isolated RPC session:
- Fresh `createServer()` on port 0 (OS-assigned ephemeral port)
- Unique `execId` (8 random bytes) and `token` (32 random bytes) per execution
- `ExecutionContext` struct holds per-execution state: `fns`, `onReturn`, `deadlineMs`, `rpcCallCount`
- The `fns` map is frozen with `Object.freeze()` so sandbox code can't mutate it
- The sandbox sends `execId` in every RPC call; the server validates it matches the session
- `ActiveSession` tracking with cleanup on completion, error, or timeout

**Files:** `executor.ts` (complete rewrite of RPC layer)

---

## 2. AsyncLocalStorage Context Preservation

**Problem:** Nitro uses `AsyncLocalStorage` to carry per-request context (H3 event, auth, etc.). When Code Mode dispatches a tool call via HTTP RPC, the async context is lost — the RPC handler runs in the HTTP server's context, not the original request's.

**Solution:** On entry to `execute()`, we capture the current async context via `AsyncLocalStorage.snapshot()`. Every tool dispatch is wrapped through `restoreContext()`, which re-enters the original request's async context before calling the tool handler. This means tools called from sandbox code have access to the same `useEvent()`, auth state, etc. as if called directly.

When `snapshot()` is unavailable (Node.js < 18.16.0), execution degrades gracefully: a passthrough function is used instead, and a one-time warning is logged via `console.warn`. Tools still work but lose access to request context (`useEvent()`, auth, etc.) — matching the behavior of main before this branch. This preserves backward compatibility with Node.js 18.0+.

**Files:** `executor.ts`

---

## 3. Resource Limits & Abuse Prevention

**Problem:** The original executor had no protection against:
- Oversized RPC request bodies (memory exhaustion)
- Infinite tool call loops
- Runaway wall-clock time (sandbox waiting forever on slow tools)
- Oversized tool responses

**Solution:** Added configurable limits with sensible defaults:

| Limit | Default | Config Key | Enforcement |
|-------|---------|------------|-------------|
| RPC request body | 1 MB | `maxRequestBodyBytes` | HTTP 413, streaming byte count |
| Tool calls per execution | 200 | `maxToolCalls` | HTTP 429, counter on `ExecutionContext` |
| Wall-clock timeout | 60s | `wallTimeLimitMs` | `setTimeout` → `runtime.dispose()` |
| Tool response size | 1 MB | `maxToolResponseSize` | Truncation (same strategy as `maxResultSize`) |

The wall-clock timeout is separate from the V8 CPU time limit. CPU time only counts isolate execution; wall time caps total elapsed time including host-side tool calls. On timeout, the runtime is forcefully disposed and the sandbox gets a clear error.

Error messages returned to sandbox/client are sanitized: file paths are replaced with `[path]`, stack traces are stripped, and messages are truncated to 500 chars. Full errors are logged server-side with `console.error('[nuxt-mcp-toolkit] ...')`.

**Files:** `executor.ts`, `types.ts` (new options), `8.code-mode.md` (docs)

---

## 4. structuredContent Dispatch

**Problem:** When a tool handler returned `structuredContent` (the MCP spec's typed data channel), Code Mode ignored it and fell through to extracting text from `content[].text`. This silently lost IDs, booleans, nested objects — breaking operation chaining where a returned ID is needed for follow-up calls.

**Solution:** `normalizeDispatchResult()` now checks `structuredContent` first:
1. If `rawResult.structuredContent != null` → return it directly (preserves typed data)
2. If `rawResult.isError` → convert to `CodeModeToolError` sentinel (see #5)
3. If `rawResult.content` has text items → return joined text (no JSON.parse — intentional, avoids ambiguity)
4. Plain objects/primitives pass through unchanged

The function also uses `isCallToolResult()` to distinguish MCP results from plain objects returned by handlers. This duck-type check was tightened: `isError` alone no longer matches unless it's a boolean (prevents false positives from objects that happen to have an `isError` property).

**Files:** `index.ts` (normalizeDispatchResult, extractTextContent), `results.ts` (isCallToolResult)

---

## 5. Tool Error Surfacing in Sandbox

**Problem:** Tool errors (`isError: true` results or thrown exceptions) were returned as plain strings to sandbox code, making them indistinguishable from successful results. `try/catch` never fired, and structured error details from `structuredContent` were lost.

**Solution:** Tool errors are now wrapped as a sentinel object with a namespaced key:

```ts
{
  __mcp_toolkit_error__: true,
  message: "Permission denied",
  tool: "delete_item",
  details: { /* structuredContent if available */ }
}
```

The sandbox proxy code detects this sentinel and throws a structured `Error` with `.tool`, `.isToolError`, and `.details` properties. This lets sandbox code use `try/catch` to handle tool errors with full context.

The sentinel key is namespaced (`__mcp_toolkit_error__`) rather than generic (`__toolError`) to avoid collisions with legitimate tool return values. Similarly, the stderr error prefix is `__MCP_EXEC_ERR__` rather than `__ERROR__`.

**Files:** `index.ts` (toToolError, CodeModeToolError), `executor.ts` (proxy boilerplate)

---

## 6. Typed Output Schemas

**Problem:** All Code Mode tools returned `Promise<unknown>` regardless of whether an `outputSchema` was defined. The LLM had no type information about what to expect back.

**Solution:** When a tool definition includes `outputSchema`, the type generator now emits typed return values:
- Small schemas (<=3 primitive fields) are inlined: `Promise<{ id: string; ok: boolean }>`
- Larger schemas get named interfaces: `Promise<GetReportOutput>`

This reuses the same `generateSchemaTypeInfo()` helper used for input schemas, extracted from the duplicated inline logic.

**Files:** `types.ts` (generateSchemaTypeInfo, generateToolTypeInfo output handling)

---

## 7. Type Generation Improvements

Several improvements to the TypeScript type generation for sandbox code:

- **Property key escaping:** Keys with special characters or reserved words are now properly quoted using `JSON.stringify()` via `formatTsPropertyKey()`. Before: `my-key?: string` (invalid TS). After: `"my-key"?: string`.
- **Enum value escaping:** Enum strings containing quotes or backslashes are now escaped with `JSON.stringify(v)` instead of template literals. Before: `"he said "hello""` (broken). After: `"he said \"hello\""`.
- **Name collision detection:** `buildToolNameMap()` now warns via `console.warn` if two tools sanitize to the same name (e.g., `get-user` and `get_user` both become `get_user`), keeping last-wins behavior for backward compatibility. The warning message includes a notice that this will become an error in a future version.

**Files:** `types.ts`

---

## 8. Description Templates & Progressive Mode

**Problem:** The code tool descriptions were overly verbose with multi-paragraph instructions about combining sequential/parallel/conditional logic. This wastes context window for every tool call.

**Solution:**
- Simplified templates to essential information: what the tool does, how to write code, available types
- Added `{{example}}` placeholder support alongside existing `{{types}}` and `{{count}}`
- Example blocks are automatically omitted when there are >10 tools (they become noise at that scale)
- Collapsed excessive newlines in template output
- Progressive mode gets its own concise example showing the search→code workflow

**Files:** `index.ts` (templates, applyDescriptionTemplate), `types.ts` (CodeModeOptions.description docs)

---

## 9. Structured Envelope Responses

**Problem:** The code tool returned only text content — no structured data for programmatic consumption by MCP clients.

**Solution:** The code tool now returns both `structuredContent` and `content`:

```ts
{
  isError: false,
  structuredContent: {
    ok: true,
    result: { id: "abc123" },
    durationMs: 142,
    logs: ["[stdout] Processing..."]
  },
  content: [{ type: "text", text: "..." }]  // human-readable fallback
}
```

- `CodeToolEnvelope` is a discriminated union (`ok: true | false`) preventing impossible states (simultaneous result + error)
- `ExecuteResult` is also a discriminated union — `result` and `error` are mutually exclusive at the type level
- `durationMs` tracks wall-clock execution time
- `outputSchema` is declared on the code tool definition so MCP clients can validate responses

**Files:** `index.ts` (CodeToolEnvelope, createCodeToolEnvelope, formatSuccessContent), `types.ts` (ExecuteResult)

---

## 10. Handler Reuse Between Registration and Code Mode

**Problem:** Code Mode reimplemented tool handler invocation: it manually resolved tool names, manually checked for `inputSchema`, and called handlers differently than `registerToolFromDefinition()`. This meant cache wrappers, error normalization, and future middleware would only apply to registered tools, not code mode dispatches.

**Solution:** Extracted shared utilities from `registerToolFromDefinition()`:
- `resolveToolDefinitionName(tool)` — applies `enrichNameTitle` to get the canonical name
- `createWrappedToolHandler(tool)` — applies cache wrappers and returns the handler
- `invokeWrappedToolHandler(tool, handler, input, extra)` — calls the handler with the correct argument shape. Uses `tool.inputSchema !== undefined` (not `Object.keys(...).length > 0`) to determine the call shape, correctly handling `inputSchema: {}` which is a valid empty schema where the handler still receives `(args, extra)`

Code Mode now uses these same functions, so cache, auth, and any future middleware apply consistently whether a tool is called via MCP protocol or via sandbox code.

The `buildDispatchFunctions()` helper is now exported (used by tests) and accepts `McpRequestExtra`, which gets passed through to tool handlers so they have access to `requestId`, `signal`, `sendNotification`, etc.

**Files:** `tools.ts` (resolveToolDefinitionName, createWrappedToolHandler, invokeWrappedToolHandler), `index.ts` (buildDispatchEntries, buildDispatchFunctionsFromEntries)

---

## 11. Hardening Pass (PR Review Fixes)

After the feature work, a comprehensive PR review identified issues that were fixed:

### Error sentinel spoofability
Changed sentinel key from `__toolError` to `__mcp_toolkit_error__` and stderr prefix from `__ERROR__` to `__MCP_EXEC_ERR__` to avoid collisions with legitimate tool return values or user code logging.

### Empty catch blocks
Four truly empty `catch {}` blocks in cleanup paths (server.close, runtime.dispose, wall-timer dispose) now log warnings with `console.warn('[nuxt-mcp-toolkit] ...')` and context about which operation failed.

### Unhandled promise rejection
`void handleRpcRequest(...)` had no catch handler. If the inner try/catch failed AND `sendJson` also threw, the rejection escaped. Added `.catch(() => { if (!res.headersSent) res.destroy() })` as a safety net.

### Missing server-side error logging
The outer `catch` in `execute()` sanitized errors before returning them but never logged the raw error. Added `console.error('[nuxt-mcp-toolkit] Execution error:', error)` before sanitization so infrastructure errors are visible in server logs.

### isCallToolResult false positives
`isError` alone was enough to match `isCallToolResult()`. Now requires `typeof isError === 'boolean'` — objects with incidental string/number `isError` properties aren't misrouted.

### Dead proxy cache
`cachedProxyKey`/`cachedProxyCode` module-level variables never hit because each execution creates a new port+token. Removed entirely.

### Impossible type states
`ExecuteResult` was `{ result: unknown, error?: string }` — both could be set. Now a discriminated union where `result` and `error` are mutually exclusive. Same for `CodeToolEnvelope` with `ok` as discriminant.

### disposeCodeMode error swallowing
`.catch(() => {})` replaced with `.catch(error => console.warn(...))`.

### Empty-schema dispatch fix
`invokeWrappedToolHandler` was checking `Object.keys(tool.inputSchema).length > 0` which treated `inputSchema: {}` as "no schema", calling `handler(extra)` instead of `handler({}, extra)`. Fixed to check `tool.inputSchema !== undefined`. This was a pre-existing bug on main that was surfaced during the handler extraction refactor.

**Files:** `executor.ts`, `index.ts`, `types.ts`, `results.ts`, `tools.ts`

---

## 12. Annotation Surfacing & Grouped Progressive Search

**Problem:** MCP annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`) were defined on tool definitions but invisible in code mode. Progressive mode search results were a flat list with no grouping.

**Solution:** Derive more from existing metadata, configure nothing new.

### 12a. Annotation surfacing

`buildAnnotationTags()` converts existing MCP annotations into compact tags prepended to the `// comment` in type signatures:

- `readOnlyHint: true` → `[read-only]`
- `destructiveHint: true` → `[destructive]`
- `idempotentHint: true` → `[idempotent]`

```ts
declare const codemode: {
  list_items: () => Promise<Runbook[]>; // [read-only] [idempotent] List all runbooks
  delete_runbook: (input: { id: string }) => Promise<unknown>; // [destructive] Permanently removes
};
```

Tags use text (not emoji) for token efficiency. Both annotation tags and description comments are always preserved in the type block — the `// description` comment is the primary way the LLM understands tool semantics in standard mode. When annotations are present, tags are prepended to the description (e.g., `// [read-only] List all items`). Tools without annotations retain their plain `// description` comment.

### 12b. Grouped progressive search

`formatSearchResults()` groups results by the existing `group` field (auto-inferred from directory structure, e.g., `server/mcp/tools/workspace/` → `'workspace'`):

```
Found 3/6 tools matching "runbook":

## workspace

codemode.create_runbook: (input: CreateRunbookInput) => Promise<{ ok: boolean; data: { id: string } }>;
codemode.delete_runbook: (input: { id: string }) => Promise<unknown>; // [destructive] Permanent

## public

codemode.search_public: (input: { q: string }) => Promise<Runbook[]>; // [read-only] Full-text search
```

- Groups come from `tool.group` or `tool._meta.group`
- When no tools have groups, output is flat — fully backward-compatible


## 13. Test Coverage

### codemode.test.ts (~530 lines)
- Type generation: declarations with descriptions, output types, name collision warning
- Tool catalog: signatures, search formatting
- `createCodemodeTools`: standard mode, progressive mode, example block omission, outputSchema
- `buildDispatchFunctions`: structuredContent preference, plain text preservation, native object passthrough, thrown error → sentinel conversion, MCP extra propagation, empty-schema extra passing, undefined-schema extra passing
- Code tool envelope: structured success/error responses
- `normalizeCode`: markdown fence stripping, arrow function unwrapping, export default removal
- `isCallToolResult`: content arrays, structuredContent, boolean isError, non-boolean isError rejection, plain object rejection
- Enum escaping: quotes, backslashes in enum values
- `isError` CallToolResult → tool error sentinel flow (including structuredContent details)
- Annotation surfacing: `[read-only]`, `[destructive]`, `[idempotent]` tags; combined tags
- Grouped search: group headers, mixed grouped/ungrouped, flat fallback
- Backward compat: tools without annotations produce identical output
- Annotation vs description: all tools preserve descriptions, annotated tools get tags prepended

### codemode-executor.test.ts (new, ~450 lines)
- Concurrency: parallel executions with no cross-talk
- AsyncLocalStorage context preservation
- AsyncLocalStorage fallback: graceful degradation when snapshot unavailable, one-time warning
- RPC token validation: wrong token → 403
- Execution ID validation: wrong execId → 400
- Request body limits: oversized payload → 413
- Tool call quota: exceeding maxToolCalls → 429
- Tool response truncation: arrays, objects, primitives
- Wall-clock timeout behavior
- Cleanup verification after success/error/timeout

---

## 14. Documentation Updates

- `8.code-mode.md`: Added new config options (`maxRequestBodyBytes`, `maxToolResponseSize`, `wallTimeLimitMs`, `maxToolCalls`) to the configuration reference and resource limits table. Added "Error Sanitization" section. Added Node.js >=18.16.0 callout. Added "Annotation Surfacing" section. Updated progressive mode section with grouped search output example.
- `handlers.ts`: Expanded `experimental_codeMode` JSDoc with config keys and Node.js requirement.
- `2.installation.md`: Minor addition (context for secure-exec requirement).

---

## Files Changed Summary

| File | What changed |
|------|-------------|
| `executor.ts` | Rewritten: per-session RPC, AsyncLocalStorage, resource limits, error handling |
| `index.ts` | Rewritten: structuredContent dispatch, tool error sentinels, envelope responses, handler reuse |
| `types.ts` | Extended: output schemas, property key escaping, enum escaping, discriminated unions, `buildAnnotationTags`, grouped `formatSearchResults` |
| `tools.ts` | Extracted `resolveToolDefinitionName`, `createWrappedToolHandler`, `invokeWrappedToolHandler` |
| `results.ts` | Exported `isCallToolResult`, tightened `isError` check |
| `handlers.ts` | JSDoc update for `experimental_codeMode` |
| `executor.cloudflare.ts` | Re-export alignment |
| `codemode.test.ts` | Expanded from ~180 to ~450 lines |
| `codemode-executor.test.ts` | New: ~400 lines of executor integration tests |
| `8.code-mode.md` | New config options, resource limits table, error sanitization, annotation surfacing, grouped progressive search |
| `2.installation.md` | Minor addition |
| `5.handlers.md` | Minor addition |

## How Everything Connects

```
Tool Definition (defineMcpTool)
  ├── name, description, inputSchema, outputSchema, annotations, group
  │
  ▼
registerToolFromDefinition (tools.ts)
  ├── enrichNameTitle → canonical name
  ├── _meta: { inputExamples, group, tags }
  │
  ▼
createCodemodeTools (index.ts)
  ├── Standard mode: generateTypesFromTools → type block
  │   ├── buildAnnotationTags reads annotations → [read-only] etc. prepended to description
  │   ├── All tool descriptions preserved in type block (LLM's primary tool semantics source)
  │   └── hardcoded example block (omitted when >10 tools)
  │
  ├── Progressive mode: generateToolCatalog → searchable entries
  │   ├── ToolCatalogEntry: { group, annotations }
  │   └── formatSearchResults → grouped by group field with ## headers
  │
  ▼
buildDispatchEntries → buildDispatchFunctionsFromEntries (index.ts)
  ├── createWrappedToolHandler (shared with registerToolFromDefinition)
  ├── invokeWrappedToolHandler (shared with registerToolFromDefinition)
  ├── normalizeDispatchResult → structuredContent preference, error sentinels
  │
  ▼
execute (executor.ts)
  ├── Per-session RPC server (port 0, unique token + execId)
  ├── AsyncLocalStorage.snapshot → context preservation
  ├── Resource limits (CPU, wall-clock, memory, request body, tool calls)
  ├── Error sanitization
  │
  ▼
Code tool response (CodeToolEnvelope)
  ├── structuredContent: { ok, result?, error?, logs?, durationMs }
  └── content: [{ type: "text", text: "..." }]  (human-readable fallback)
```

**Key design principle:** Derive from existing MCP metadata (`annotations`, `group`, `outputSchema`, `description`), don't add new per-tool config surface. Every feature is additive and optional — tools without annotations or groups produce identical output to before.
