### PR TITLE
fix(module): harden transport origin checks and session lifecycle

### DIFF
--- a/apps/docs/content/1.getting-started/3.configuration.md
+++ b/apps/docs/content/1.getting-started/3.configuration.md
@@ -76,11 +76,12 @@ All available configuration options:
   ::field{name="sessions" type="boolean | object"}
     Default: `false`
 
-    Enable [MCP session management](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management) (stateful transport). When enabled, the server assigns session IDs via the `MCP-Session-Id` header and maintains state across requests, enabling SSE streaming, server-to-client notifications, and resumability.
+    Enable [MCP session management](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management) (stateful transport). When enabled, the server assigns session IDs via the `MCP-Session-Id` header and maintains state across requests, enabling SSE streaming, server-to-client notifications, and session continuity.
 
     Pass `true` for defaults or an object with:
     - `enabled` - Enable or disable sessions
     - `maxDuration` - Session timeout in milliseconds (default: `1800000` / 30 minutes)
+    - `maxSessions` - Maximum concurrent sessions before new session creation returns `503` (default: `1000`)
   ::
 ::
 

--- a/apps/docs/content/1.getting-started/3.configuration.md
+++ b/apps/docs/content/1.getting-started/3.configuration.md
@@ -81,7 +81,15 @@ All available configuration options:
     Pass `true` for defaults or an object with:
     - `enabled` - Enable or disable sessions
     - `maxDuration` - Session timeout in milliseconds (default: `1800000` / 30 minutes)
-    - `maxSessions` - Maximum concurrent sessions before new session creation returns `503` (default: `1000`)
+    - `maxSessions` - Maximum concurrent sessions before new session creation returns `503` (default: `1000`). Enforced on the **Node** Nitro server only; Cloudflare Workers use the `agents/mcp` path in this module, which does not apply this cap.
+  ::
+
+  ::field{name="security" type="object"}
+    Optional. Hardens [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security) requests.
+
+    - `allowedOrigins` — `undefined` (default): allow requests with no `Origin` header (typical for same-origin and CLI); otherwise require `Origin` to match the server origin (scheme + host + port). Use the literal `'*'` in config to disable Origin checks (explicit opt-out). `string[]` — allow only listed origins (each entry is normalized to an origin URL).
+
+    Cross-site browser clients must send an allowed `Origin` or receive **403**.
   ::
 ::
 
@@ -127,6 +135,22 @@ export default defineNuxtConfig({
   modules: ['@nuxtjs/mcp-toolkit'],
   mcp: {
     browserRedirect: '/docs/mcp', // Redirect browsers to documentation
+  },
+})
+```
+
+### Streamable HTTP security (`allowedOrigins`)
+
+When browsers call your MCP endpoint from another site, they send an `Origin` header. By default the module requires that origin to match your app. Allow a SPA on another host (or disable checks only in controlled environments):
+
+```typescript [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/mcp-toolkit'],
+  mcp: {
+    security: {
+      allowedOrigins: ['https://my-app.vercel.app'],
+      // allowedOrigins: '*' // explicit opt-out — use with care
+    },
   },
 })
 ```

--- a/apps/docs/content/3.advanced/6.sessions.md
+++ b/apps/docs/content/3.advanced/6.sessions.md
@@ -23,7 +23,7 @@ Add session support to my Nuxt MCP server (@nuxtjs/mcp-toolkit).
 - Define a TypeScript interface for your session data and pass it as the generic parameter to useMcpSession<MySession>()
 - Sessions are identified by the MCP-Session-Id header, assigned automatically
 - For custom timeout: mcp: { sessions: { enabled: true, maxDuration: 3600000 } }
-- Sessions also enable SSE streaming and resumability
+- Sessions also enable SSE streaming and session continuity
 
 Docs: https://mcp-toolkit.nuxt.dev/advanced/sessions
 ```
@@ -34,7 +34,7 @@ When sessions are enabled, the server assigns a unique `MCP-Session-Id` to each 
 
 - **Maintain state** across multiple tool calls within the same conversation
 - **Enable SSE streaming** for real-time server-to-client communication
-- **Support resumability** so clients can reconnect to an existing session
+- **Support session continuity** so clients can reconnect to an existing session
 
 ## When to Use Sessions
 
@@ -285,6 +285,33 @@ Session data is **automatically cleaned up** when:
 - A session expires after `maxDuration` of inactivity (default: 30 minutes)
 
 You don't need to manage cleanup manually.
+
+## Session Invalidation
+
+Use `invalidateMcpSession()` (auto-imported) to terminate the current session programmatically. This is useful when auth state changes (e.g., token revocation) and you want to force the client to re-initialize:
+
+```typescript [server/mcp/index.ts]
+export default defineMcpHandler({
+  middleware: async (event) => {
+    const isRevoked = await checkIfTokenRevoked(event)
+    if (isRevoked) {
+      invalidateMcpSession()
+    }
+  },
+})
+```
+
+::callout{icon="i-lucide-info" color="info"}
+`enabled` guards on tools, resources, and prompts are evaluated when the session is created. If auth state changes mid-session, call `invalidateMcpSession()` to force re-evaluation.
+::
+
+::callout{icon="i-lucide-info" color="info"}
+`invalidateMcpSession()` marks the current session for teardown after the in-flight request finishes. If you need to reject the current request immediately, return a `401`/`403` response from middleware after calling it.
+::
+
+## Session Continuity vs Resumability
+
+The current implementation provides **session continuity** — a client can make multiple requests using the same `MCP-Session-Id` and the server maintains state across them. This is not the same as **SSE event replay** (true resumability), which would require an `eventStore` to replay missed events after a reconnection. SSE event replay may be added in a future release.
 
 ## Requirements
 

--- a/apps/docs/content/3.advanced/6.sessions.md
+++ b/apps/docs/content/3.advanced/6.sessions.md
@@ -306,7 +306,7 @@ export default defineMcpHandler({
 ::
 
 ::callout{icon="i-lucide-info" color="info"}
-`invalidateMcpSession()` marks the current session for teardown after the in-flight request finishes. If you need to reject the current request immediately, return a `401`/`403` response from middleware after calling it.
+**Node:** invalidation is tied to the HTTP response — the current MCP request can still complete with **200**, then storage and transport are torn down; the next request with the same `MCP-Session-Id` gets **404**. **Cloudflare Workers:** the session is marked invalid before your handler runs; the same request still completes, but the next request with that id gets **404**. To reject the in-flight MCP call immediately on any runtime, return **401**/**403** from middleware (optionally after calling `invalidateMcpSession()`).
 ::
 
 ## Session Continuity vs Resumability

--- a/packages/nuxt-mcp-toolkit/src/module.ts
+++ b/packages/nuxt-mcp-toolkit/src/module.ts
@@ -6,6 +6,7 @@ import { ROUTES } from './runtime/server/mcp/constants'
 import { detectIDE, findInstalledMCPConfig, generateDeeplinkUrl, IDE_CONFIGS, terminalLink } from './utils/ide'
 import { name, version } from '../package.json'
 import type { McpIcon } from './runtime/server/mcp/definitions/handlers'
+import type { McpSecurityConfig } from './runtime/server/mcp/config'
 
 const log = logger.withTag('@nuxtjs/mcp-toolkit')
 
@@ -83,7 +84,7 @@ export interface ModuleOptions {
   /**
    * Enable MCP session management (stateful transport).
    * When enabled, the server assigns session IDs and maintains state across requests,
-   * enabling SSE streaming, server-to-client notifications, and resumability.
+   * enabling SSE streaming, server-to-client notifications, and session continuity.
    *
    * Pass `true` for defaults or an object to configure session behavior.
    * @default false
@@ -96,7 +97,17 @@ export interface ModuleOptions {
      * @default 1800000 (30 minutes)
      */
     maxDuration?: number
+    /**
+     * Maximum number of concurrent sessions. Returns 503 when exceeded.
+     * @default 1000
+     */
+    maxSessions?: number
   }
+  /**
+   * Security configuration for the MCP server.
+   * @see https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning
+   */
+  security?: McpSecurityConfig
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -133,6 +144,7 @@ export default defineNuxtModule<ModuleOptions>({
     if (mcpConfig.sessions.enabled && nitroOptions) {
       nitroOptions.storage ??= {}
       nitroOptions.storage['mcp:sessions'] ??= { driver: 'memory' }
+      nitroOptions.storage['mcp:sessions-meta'] ??= { driver: 'memory' }
     }
 
     if (options.autoImports !== false) {
@@ -307,6 +319,7 @@ export default defineNuxtModule<ModuleOptions>({
 
       addServerImports([
         { name: 'useMcpSession', from: mcpSessionPath },
+        { name: 'invalidateMcpSession', from: mcpSessionPath },
         { name: 'useMcpServer', from: mcpServerPath },
       ])
     }

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/config.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/config.ts
@@ -3,6 +3,17 @@ import type { McpIcon } from './definitions/handlers'
 export interface McpSessionsConfig {
   enabled: boolean
   maxDuration: number
+  maxSessions: number
+}
+
+export interface McpSecurityConfig {
+  /**
+   * Allowed origins for Streamable HTTP requests.
+   * - `undefined` (default): same-origin enforcement (compare against the request origin)
+   * - `'*'`: disable origin checks (explicit opt-out)
+   * - `string[]`: allow only these origins
+   */
+  allowedOrigins?: string[] | '*'
 }
 
 export interface McpConfig {
@@ -16,6 +27,7 @@ export interface McpConfig {
   icons?: McpIcon[]
   dir: string
   sessions: McpSessionsConfig
+  security: McpSecurityConfig
 }
 
 export const defaultMcpConfig: McpConfig = {
@@ -28,7 +40,9 @@ export const defaultMcpConfig: McpConfig = {
   sessions: {
     enabled: false,
     maxDuration: 30 * 60 * 1000, // 30 minutes
+    maxSessions: 1000,
   },
+  security: {},
 }
 
 export function getMcpConfig(partial?: Partial<McpConfig>): McpConfig {
@@ -36,6 +50,9 @@ export function getMcpConfig(partial?: Partial<McpConfig>): McpConfig {
   const sessions = partial.sessions
     ? { ...defaultMcpConfig.sessions, ...partial.sessions }
     : defaultMcpConfig.sessions
+  const security = partial.security
+    ? { ...defaultMcpConfig.security, ...partial.security }
+    : defaultMcpConfig.security
   return {
     enabled: partial.enabled ?? defaultMcpConfig.enabled,
     route: partial.route ?? defaultMcpConfig.route,
@@ -47,5 +64,6 @@ export function getMcpConfig(partial?: Partial<McpConfig>): McpConfig {
     icons: partial.icons,
     dir: partial.dir ?? defaultMcpConfig.dir,
     sessions,
+    security,
   }
 }

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/providers/cloudflare.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/providers/cloudflare.ts
@@ -1,5 +1,9 @@
 import { createMcpTransportHandler } from './types'
-import { toWebRequest } from '../compat'
+import { getHeader, toWebRequest } from '../compat'
+import { validateOrigin } from './security'
+import { isSessionInvalidated, isSessionInvalidationRequested, markSessionInvalidated } from '../session-state'
+// @ts-expect-error - Generated template
+import config from '#nuxt-mcp-toolkit/config.mjs'
 
 interface CloudflareContext {
   env: Record<string, unknown>
@@ -16,7 +20,31 @@ const fallbackCtx: ExecutionContext = {
   passThroughOnException: () => {},
 }
 
+function createJsonRpcErrorResponse(status: number, code: number, message: string): Response {
+  return new Response(JSON.stringify({
+    jsonrpc: '2.0',
+    error: { code, message },
+    id: null,
+  }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
 export default createMcpTransportHandler(async (createServer, event) => {
+  const securityConfig = config.security ?? {}
+  const originError = validateOrigin(event, securityConfig)
+  if (originError) return originError
+
+  const sessionId = getHeader(event, 'mcp-session-id')
+  if (sessionId && await isSessionInvalidated(sessionId)) {
+    return createJsonRpcErrorResponse(404, -32_001, 'Session not found')
+  }
+
+  if (sessionId && isSessionInvalidationRequested(event)) {
+    await markSessionInvalidated(sessionId)
+  }
+
   const server = createServer()
   event.context._mcpServer = server
   const { createMcpHandler } = await import('agents/mcp')

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/providers/node.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/providers/node.ts
@@ -155,6 +155,8 @@ export default createMcpTransportHandler(async (createServer, event) => {
         clearSessionInvalidation(sid),
       ])
     }
+    // Do not call server.close() here: this runs during transport shutdown;
+    // explicit cleanup uses deleteSession() (invalidation, idle expiry, duplicate guard).
   }
 
   await server.connect(transport)

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/providers/node.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/providers/node.ts
@@ -3,6 +3,8 @@ import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/
 import type { H3Event } from 'h3'
 import { useStorage } from 'nitropack/runtime'
 import { getHeader, toWebRequest } from '../compat'
+import { validateOrigin, isValidSessionId } from './security'
+import { clearSessionInvalidation, isSessionInvalidated, isSessionInvalidationRequested, markSessionInvalidated } from '../session-state'
 // @ts-expect-error - Generated template
 import config from '#nuxt-mcp-toolkit/config.mjs'
 import { createMcpTransportHandler } from './types'
@@ -17,16 +19,37 @@ const sessions = new Map<string, Session>()
 
 let cleanupInterval: ReturnType<typeof setInterval> | null = null
 
+function createJsonRpcErrorResponse(status: number, code: number, message: string): Response {
+  return new Response(JSON.stringify({
+    jsonrpc: '2.0',
+    error: { code, message },
+    id: null,
+  }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function deleteSession(sessionId: string): Promise<boolean> {
+  const session = sessions.get(sessionId)
+  if (!session) return false
+  sessions.delete(sessionId)
+  await Promise.all([
+    useStorage(`mcp:sessions:${sessionId}`).clear(),
+    clearSessionInvalidation(sessionId),
+  ])
+  session.transport.close()
+  session.server.close()
+  return true
+}
+
 function ensureCleanup(maxDuration: number) {
   if (cleanupInterval) return
   cleanupInterval = setInterval(() => {
     const now = Date.now()
     for (const [id, session] of sessions) {
       if (now - session.lastAccessed > maxDuration) {
-        session.transport.close()
-        session.server.close()
-        sessions.delete(id)
-        useStorage(`mcp:sessions:${id}`).clear()
+        void deleteSession(id)
       }
     }
     if (sessions.size === 0 && cleanupInterval) {
@@ -45,6 +68,10 @@ function onResponseClose(event: H3Event, fn: () => void) {
 }
 
 export default createMcpTransportHandler(async (createServer, event) => {
+  const securityConfig = config.security ?? {}
+  const originError = validateOrigin(event, securityConfig)
+  if (originError) return originError
+
   const sessionsConfig = config.sessions
   const sessionsEnabled = sessionsConfig?.enabled ?? false
   const request = toWebRequest(event)
@@ -65,21 +92,45 @@ export default createMcpTransportHandler(async (createServer, event) => {
   const sessionId = getHeader(event, 'mcp-session-id')
 
   if (sessionId) {
+    if (!isValidSessionId(sessionId)) {
+      return createJsonRpcErrorResponse(400, -32_600, 'Invalid session ID format')
+    }
+
+    if (await isSessionInvalidated(sessionId)) {
+      if (!await deleteSession(sessionId)) {
+        await clearSessionInvalidation(sessionId)
+      }
+      return createJsonRpcErrorResponse(404, -32_001, 'Session not found')
+    }
+
     const session = sessions.get(sessionId)
     if (!session) {
-      return new Response(JSON.stringify({
-        jsonrpc: '2.0',
-        error: { code: -32_001, message: 'Session not found' },
-        id: null,
-      }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
+      return createJsonRpcErrorResponse(404, -32_001, 'Session not found')
     }
 
     session.lastAccessed = Date.now()
     event.context._mcpServer = session.server
+
+    if (isSessionInvalidationRequested(event)) {
+      await markSessionInvalidated(sessionId)
+      onResponseClose(event, () => {
+        void deleteSession(sessionId)
+      })
+    }
+
     return session.transport.handleRequest(request)
+  }
+
+  const maxSessions: number = sessionsConfig?.maxSessions ?? 1000
+  if (sessions.size >= maxSessions) {
+    return new Response(JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code: -32_001, message: 'Server session limit reached' },
+      id: null,
+    }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json', 'Retry-After': '60' },
+    })
   }
 
   const server = createServer()
@@ -99,9 +150,11 @@ export default createMcpTransportHandler(async (createServer, event) => {
     const sid = transport.sessionId
     if (sid && sessions.has(sid)) {
       sessions.delete(sid)
-      useStorage(`mcp:sessions:${sid}`).clear()
+      void Promise.all([
+        useStorage(`mcp:sessions:${sid}`).clear(),
+        clearSessionInvalidation(sid),
+      ])
     }
-    server.close()
   }
 
   await server.connect(transport)

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/providers/security.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/providers/security.ts
@@ -1,0 +1,77 @@
+import type { H3Event } from 'h3'
+import { getRequestURL } from 'h3'
+import type { McpSecurityConfig } from '../config'
+import { getHeader } from '../compat'
+
+const UUID_RE = /^[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/i
+
+/**
+ * Validate that a session ID is a valid UUID v4.
+ */
+export function isValidSessionId(id: string): boolean {
+  return UUID_RE.test(id)
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * Validate the Origin header against the allowed origins configuration.
+ * Returns a 403 Response if the origin is rejected, or `null` if the request is allowed.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security
+ */
+export function validateOrigin(event: H3Event, security: McpSecurityConfig): Response | null {
+  // Wildcard disables origin checks (explicit opt-out)
+  if (security.allowedOrigins === '*') {
+    return null
+  }
+
+  const origin = getHeader(event, 'origin')
+
+  // Requests without an Origin header are typically same-origin
+  // (browsers attach Origin only to cross-origin or unsafe requests)
+  if (!origin) {
+    return null
+  }
+
+  const normalizedOrigin = normalizeOrigin(origin)
+  if (!normalizedOrigin) {
+    return new Response(JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code: -32_600, message: 'Origin not allowed' },
+      id: null,
+    }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  if (Array.isArray(security.allowedOrigins)) {
+    // Explicit allowlist
+    if (security.allowedOrigins.some(allowedOrigin => normalizeOrigin(allowedOrigin) === normalizedOrigin)) {
+      return null
+    }
+  }
+  else {
+    // Default: same-origin enforcement — compare full origin including scheme and port.
+    if (normalizedOrigin === getRequestURL(event).origin) {
+      return null
+    }
+  }
+
+  return new Response(JSON.stringify({
+    jsonrpc: '2.0',
+    error: { code: -32_600, message: 'Origin not allowed' },
+    id: null,
+  }), {
+    status: 403,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/session-state.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/session-state.ts
@@ -1,0 +1,37 @@
+import type { H3Event } from 'h3'
+import { useStorage } from 'nitropack/runtime'
+import { getHeader } from './compat'
+
+const INVALIDATED_AT_KEY = 'invalidatedAt'
+
+function getSessionMetaStorage(sessionId: string) {
+  return useStorage(`mcp:sessions-meta:${sessionId}`)
+}
+
+export function getRequestSessionId(event: H3Event): string | undefined {
+  return getHeader(event, 'mcp-session-id')
+}
+
+export function requestSessionInvalidation(event: H3Event): boolean {
+  const sessionId = getRequestSessionId(event)
+  if (!sessionId) return false
+  event.context._mcpInvalidateSession = true
+  return true
+}
+
+export function isSessionInvalidationRequested(event: H3Event): boolean {
+  return Boolean(event.context._mcpInvalidateSession)
+}
+
+export async function markSessionInvalidated(sessionId: string): Promise<void> {
+  await getSessionMetaStorage(sessionId).setItem(INVALIDATED_AT_KEY, Date.now())
+}
+
+export async function isSessionInvalidated(sessionId: string): Promise<boolean> {
+  const invalidatedAt = await getSessionMetaStorage(sessionId).getItem<number>(INVALIDATED_AT_KEY)
+  return typeof invalidatedAt === 'number'
+}
+
+export async function clearSessionInvalidation(sessionId: string): Promise<void> {
+  await getSessionMetaStorage(sessionId).clear()
+}

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/session.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/session.ts
@@ -1,6 +1,8 @@
 import { useStorage, useEvent } from 'nitropack/runtime'
 import type { Storage } from 'unstorage'
 import { getHeader } from './compat'
+import { isValidSessionId } from './providers/security'
+import { requestSessionInvalidation } from './session-state'
 
 export interface McpSessionStore<T = Record<string, unknown>> {
   get<K extends keyof T & string>(key: K): Promise<T[K] | null>
@@ -22,6 +24,9 @@ export function useMcpSession<T = Record<string, unknown>>(): McpSessionStore<T>
       + 'and `nitro.experimental.asyncContext` is true.',
     )
   }
+  if (!isValidSessionId(sessionId)) {
+    throw new Error('Invalid MCP session ID format')
+  }
 
   const storage = useStorage(`mcp:sessions:${sessionId}`)
 
@@ -34,4 +39,17 @@ export function useMcpSession<T = Record<string, unknown>>(): McpSessionStore<T>
     clear: () => storage.clear(),
     storage,
   }
+}
+
+/**
+ * Terminate the current MCP session.
+ * Use this in middleware when auth state changes (e.g., token revocation)
+ * to force the client to re-initialize with a new session.
+ *
+ * Note: `enabled` guards on tools/resources/prompts evaluate at session creation.
+ * Call this to invalidate a session whose privileges should no longer apply.
+ */
+export function invalidateMcpSession(): boolean {
+  const event = useEvent()
+  return requestSessionInvalidation(event)
 }

--- a/packages/nuxt-mcp-toolkit/test/fixtures/sessions/server/mcp/index.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/sessions/server/mcp/index.ts
@@ -1,0 +1,11 @@
+import { getRequestURL } from 'h3'
+import { defineMcpHandler } from '../../../../../src/runtime/server/types'
+import { invalidateMcpSession } from '../../../../../src/runtime/server/mcp/session'
+
+export default defineMcpHandler({
+  middleware: async (event) => {
+    if (getRequestURL(event).searchParams.get('invalidateSession') === '1') {
+      invalidateMcpSession()
+    }
+  },
+})

--- a/packages/nuxt-mcp-toolkit/test/sessions.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/sessions.test.ts
@@ -68,7 +68,7 @@ describe('Session Management', async () => {
     expect(transport1.sessionId).not.toBe(transport2.sessionId)
   })
 
-  it('should return 404 for invalid session ID', async () => {
+  it('should return 400 for malformed session ID', async () => {
     const mcpUrl = createMcpUrl()
     try {
       const response = await fetch(mcpUrl.toString(), {
@@ -84,12 +84,36 @@ describe('Session Management', async () => {
           id: 1,
         }),
       })
-      expect(response.status).toBe(404)
+      expect(response.status).toBe(400)
     }
     catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error)
-      expect(message).toContain('404')
+      expect(message).toMatch(/400|404/)
     }
+  })
+
+  it('should reject cross-scheme origins even on the same host', async () => {
+    const mcpUrl = createMcpUrl()
+    const requestOrigin = `${mcpUrl.protocol}//${mcpUrl.host}`
+    const crossSchemeOrigin = requestOrigin.startsWith('https://')
+      ? requestOrigin.replace('https://', 'http://')
+      : requestOrigin.replace('http://', 'https://')
+
+    const response = await fetch(mcpUrl.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'Origin': crossSchemeOrigin,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'tools/list',
+        id: 1,
+      }),
+    })
+
+    expect(response.status).toBe(403)
   })
 
   it('should list tools within a session', async () => {
@@ -121,5 +145,44 @@ describe('Session Management', async () => {
 
     const content = result.content as Array<{ type: string, text?: string }>
     expect(content[0]?.text).toBe('NOT_FOUND')
+  })
+
+  it('should invalidate the session after the current middleware request completes', async () => {
+    const { transport } = await createSessionClient()
+    const sessionId = transport.sessionId
+    expect(sessionId).toBeDefined()
+
+    const invalidateUrl = createMcpUrl('/mcp?invalidateSession=1')
+    const currentResponse = await fetch(invalidateUrl.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'mcp-session-id': sessionId!,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'tools/list',
+        id: 1,
+      }),
+    })
+
+    expect(currentResponse.status).toBe(200)
+
+    const nextResponse = await fetch(createMcpUrl().toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'mcp-session-id': sessionId!,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'tools/list',
+        id: 2,
+      }),
+    })
+
+    expect(nextResponse.status).toBe(404)
   })
 })


### PR DESCRIPTION
### 📚 Description

This hardens the MCP Streamable HTTP transport and session lifecycle.

It fixes a few related issues in the same runtime seam:

- add configurable `Origin` validation for Streamable HTTP requests
- enforce same-origin by default, with explicit allowlist / wildcard support
- validate `MCP-Session-Id` as UUID v4 instead of treating malformed values as missing sessions
- add `sessions.maxSessions` to cap concurrent session creation
- make `invalidateMcpSession()` provider-neutral
- defer session teardown until the current request finishes, so middleware invalidation does not break the in-flight request
- reject invalidated sessions on both Node and Cloudflare
- clarify docs to describe session continuity rather than true resumability

Why this change is needed:

- the transport had no explicit origin validation
- malformed session IDs were not rejected clearly
- sessions had no admission control
- invalidation was coupled to Node internals and could cause the current request to fall through to `404`
- the docs overstated the current session model

Files changed:

- `packages/nuxt-mcp-toolkit/src/module.ts`
- `packages/nuxt-mcp-toolkit/src/runtime/server/mcp/config.ts`
- `packages/nuxt-mcp-toolkit/src/runtime/server/mcp/providers/security.ts`
- `packages/nuxt-mcp-toolkit/src/runtime/server/mcp/providers/node.ts`
- `packages/nuxt-mcp-toolkit/src/runtime/server/mcp/providers/cloudflare.ts`
- `packages/nuxt-mcp-toolkit/src/runtime/server/mcp/session.ts`
- `packages/nuxt-mcp-toolkit/src/runtime/server/mcp/session-state.ts`
- `packages/nuxt-mcp-toolkit/test/fixtures/sessions/server/mcp/index.ts`
- `packages/nuxt-mcp-toolkit/test/sessions.test.ts`
- `apps/docs/content/1.getting-started/3.configuration.md`
- `apps/docs/content/3.advanced/6.sessions.md`

Validation performed:

- `pnpm --filter @nuxtjs/mcp-toolkit exec vitest run test/sessions.test.ts`
- `pnpm --filter @nuxtjs/mcp-toolkit exec vue-tsc --noEmit`

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
