### PR TITLE
fix(module): reject file resources outside the project root

### DIFF
--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/resources.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/resources.ts
@@ -2,7 +2,7 @@ import type { H3Event } from 'h3'
 import type { Annotations } from '@modelcontextprotocol/sdk/types.js'
 import type { McpServer, ResourceTemplate, ReadResourceCallback, ReadResourceTemplateCallback, ResourceMetadata } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { readFile } from 'node:fs/promises'
-import { resolve, extname } from 'node:path'
+import { resolve, extname, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { enrichNameTitle } from './utils'
 import { type McpCacheOptions, type McpCache, createCacheOptions, wrapWithCache } from './cache'
@@ -167,7 +167,11 @@ export function registerResourceFromDefinition(
 
   // Handle file-based resources
   if ('file' in resource && resource.file) {
-    const filePath = resolve(process.cwd(), resource.file)
+    const projectRoot = process.cwd()
+    const filePath = resolve(projectRoot, resource.file)
+    if (!filePath.startsWith(projectRoot + sep)) {
+      throw new Error(`Resource file "${resource.file}" resolves outside project root`)
+    }
 
     // Auto-generate URI if not provided
     if (!uri) {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This prevents file-based MCP resources from resolving paths outside the project root.

Previously, `resource.file` was resolved with `resolve(process.cwd(), resource.file)` but there was no check that the resolved path remained inside the project directory. That allowed path traversal via definitions such as `../...`.

This change adds a guard during resource registration:

- resolve the file path relative to `process.cwd()`
- verify the resolved path stays under the project root
- throw if the path escapes the project root

This only affects invalid file-resource definitions. Valid in-project file resources continue to work as before.

Files changed:

- `packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/resources.ts`
- `packages/nuxt-mcp-toolkit/test/resource-security.test.ts`
- `packages/nuxt-mcp-toolkit/test/fixtures/invalid-file-resource/app.vue`
- `packages/nuxt-mcp-toolkit/test/fixtures/invalid-file-resource/nuxt.config.ts`
- `packages/nuxt-mcp-toolkit/test/fixtures/invalid-file-resource/package.json`
- `packages/nuxt-mcp-toolkit/test/fixtures/invalid-file-resource/server/mcp/resources/escaped-file.ts`

Validation performed:

- `pnpm --filter @nuxtjs/mcp-toolkit exec vitest run test/resource-security.test.ts`
- `pnpm --filter @nuxtjs/mcp-toolkit exec vue-tsc --noEmit`

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
