### PR TITLE
feat(module): add `useMcpElicitation`

### DIFF
--- a/.changeset/use-mcp-elicitation.md
+++ b/.changeset/use-mcp-elicitation.md
@@ -1,0 +1,26 @@
+---
+"@nuxtjs/mcp-toolkit": minor
+---
+
+Add `useMcpElicitation()` for requesting structured input from the connected client (MCP spec 2025-11-25).
+
+```typescript
+const elicit = useMcpElicitation()
+
+const result = await elicit.form({
+  message: 'Pick a release channel',
+  schema: { channel: z.enum(['stable', 'beta']) },
+})
+if (result.action !== 'accept') return 'Cancelled.'
+```
+
+- **Form mode** — pass a Zod raw shape; the response is validated and fully typed.
+- **URL mode** — `elicit.url({ message, url })` redirects the user to a hosted page (opt-in per the spec).
+- **Confirm** — `elicit.confirm(message)` returns a `boolean`.
+- **Capability check** — `elicit.supports('form' | 'url')` follows the spec's backwards compatibility rule (an empty `elicitation: {}` capability defaults to form support; once `url` is declared explicitly, `form` must be too).
+- **Typed errors** — `McpElicitationError` with `code: 'unsupported' | 'invalid-schema' | 'invalid-response'` so callers can fall back gracefully when the client doesn't support the prompt.
+- Underlying validation: Zod → JSON Schema (per the MCP spec, the schema must be a flat object of primitives, enums, or string-enum arrays — nested objects are rejected up front).
+
+The composable is auto-imported alongside the existing helpers and re-exported from `@nuxtjs/mcp-toolkit/server`. The toolkit also re-exports `useMcpServer()` and `useMcpSession()` from the same entry point.
+
+Also bumps the DevTools MCP Inspector launch budget to 60s with a fast-path that resolves as soon as the inspector emits its ready URL with the captured `MCP_PROXY_AUTH_TOKEN`, so the Inspector tab no longer times out on a cold `npx` install when testing elicitation.

--- a/apps/docs/content/3.advanced/9.elicitation.md
+++ b/apps/docs/content/3.advanced/9.elicitation.md
@@ -1,0 +1,211 @@
+---
+title: Elicitation
+description: Ask the user for structured input or send them to a URL with useMcpElicitation().
+navigation:
+  icon: i-lucide-message-square-quote
+seo:
+  title: MCP Elicitation
+  description: Request structured input from the user (form mode) or redirect them to a URL (URL mode) from your MCP tools, prompts, and resources.
+---
+
+## What is Elicitation?
+
+Elicitation lets a server ask the connected client for additional information **mid-request**. The MCP spec defines two modes:
+
+- **Form mode** — present a structured form to the user and validate the response against a schema you define.
+- **URL mode** *(spec 2025-11-25)* — redirect the user to an external page (sign-in, payment, account verification, …) and resume once they come back.
+
+::code-collapse
+
+```txt [Prompt]
+Add elicitation to my Nuxt MCP server (@nuxtjs/mcp-toolkit).
+
+- Use useMcpElicitation() inside a tool handler (auto-imported)
+- Form mode: pass a Zod raw shape via `schema` and a human-readable `message`
+- The shape must be flat — primitives, single-/multi-select enums only (spec restriction)
+- Always check the action: 'accept' | 'decline' | 'cancel' before reading content
+- URL mode: pass a `url` and `message`; client opens the URL and reports back
+- Use `confirm(message)` for a quick yes/no prompt
+- Use `supports('form' | 'url')` before calling to gate cleanly when the client doesn't support it
+- Wrap in try/catch and check for McpElicitationError (codes: 'unsupported', 'invalid-schema', 'invalid-response')
+
+Docs: https://mcp-toolkit.nuxt.dev/advanced/elicitation
+```
+
+::
+
+## When to Use Elicitation
+
+| Use Case | Mode |
+|----------|------|
+| Disambiguate input ("which project did you mean?") | `form` with an enum |
+| Confirm a destructive action before running it | `confirm` |
+| Collect missing required parameters interactively | `form` |
+| Gather optional metadata (priority, tags, …) before submitting | `form` |
+| Prompt for sign-in or payment via an external page | `url` |
+| Trigger an OAuth consent flow | `url` |
+
+::callout{icon="i-lucide-info" color="info"}
+Elicitation is **client-driven**. Even when you call it server-side, the client is the one rendering the form or opening the URL. Always handle the case where the user declines or the client doesn't support the requested mode.
+::
+
+## `useMcpElicitation()`
+
+Auto-imported. Must be called inside a tool, resource, or prompt handler.
+
+```typescript [server/mcp/tools/release.ts]
+import { z } from 'zod'
+import { defineMcpTool } from '@nuxtjs/mcp-toolkit/server'
+
+export default defineMcpTool({
+  name: 'create_release',
+  description: 'Create a new release after asking for the channel',
+  inputSchema: {
+    name: z.string(),
+  },
+  handler: async ({ name }) => {
+    const elicit = useMcpElicitation()
+
+    const result = await elicit.form({
+      message: `Pick a release channel for "${name}"`,
+      schema: {
+        channel: z.enum(['stable', 'beta', 'canary']).describe('Release channel'),
+        notify: z.boolean().default(true).describe('Notify subscribers'),
+      },
+    })
+
+    if (result.action !== 'accept') {
+      return `Release cancelled (${result.action}).`
+    }
+
+    return `Created "${name}" on ${result.content.channel} (notify=${result.content.notify}).`
+  },
+})
+```
+
+The Zod shape is converted to the spec-restricted JSON Schema, the response is validated against the same shape, and `result.content` is fully typed.
+
+### API
+
+| Method | Description |
+|--------|-------------|
+| `form({ message, schema })` | Ask for structured input. `schema` is a Zod raw shape (same format as `inputSchema`). Returns `{ action, content? }`. |
+| `url({ message, url })` | Open an external URL. Returns `{ action }`. |
+| `confirm(message)` | Convenience yes/no prompt. Returns `boolean` (`true` only when the user accepts and confirms). |
+| `supports('form' | 'url')` | Returns `true` when the connected client declared the given mode in its capabilities. |
+
+The `action` is one of `'accept' | 'decline' | 'cancel'`. The `content` field is only present when `action === 'accept'`.
+
+## Schema Restrictions (Form Mode)
+
+The MCP spec restricts elicitation requests to **flat objects with primitive properties** so any client can render them as a form. The toolkit enforces this at request time and throws `McpElicitationError('invalid-schema')` when you violate it.
+
+Allowed:
+
+- `z.string()`, `z.number()`, `z.boolean()`, `z.string().email()`, `z.number().int()`
+- `z.enum([...])` — single-select dropdown
+- `z.array(z.enum([...]))` — multi-select
+- `.describe(...)`, `.default(...)`, `.optional()`
+
+Not allowed:
+
+- Nested `z.object({ ... })`
+- `z.array(z.number())` or any array of non-string-enums
+- `z.record(...)`, `z.tuple(...)`, `z.union(...)`, `z.discriminatedUnion(...)`
+
+Need richer input? Split into multiple elicitation calls or take the data via the regular `inputSchema`.
+
+## Confirm Helper
+
+```typescript [server/mcp/tools/delete-project.ts]
+import { z } from 'zod'
+import { defineMcpTool } from '@nuxtjs/mcp-toolkit/server'
+
+export default defineMcpTool({
+  name: 'delete_project',
+  description: 'Delete a project after confirming with the user',
+  inputSchema: { id: z.string() },
+  handler: async ({ id }) => {
+    const elicit = useMcpElicitation()
+
+    if (!await elicit.confirm(`Permanently delete project ${id}?`)) {
+      return 'Aborted.'
+    }
+
+    await deleteProject(id)
+    return `Deleted ${id}.`
+  },
+})
+```
+
+`confirm()` builds on `form()` with a single `confirm: z.boolean()` field, so it inherits the same capability checks and decline handling.
+
+## URL Mode
+
+URL mode is opt-in per the spec — clients must declare `elicitation.url` in their capabilities. Use `supports('url')` to branch cleanly:
+
+```typescript [server/mcp/tools/connect-github.ts]
+import { defineMcpTool } from '@nuxtjs/mcp-toolkit/server'
+
+export default defineMcpTool({
+  name: 'connect_github',
+  description: 'Connect the user GitHub account',
+  inputSchema: {},
+  handler: async () => {
+    const elicit = useMcpElicitation()
+
+    if (!elicit.supports('url')) {
+      return 'Open https://app.example.com/settings/github to connect your account, then try again.'
+    }
+
+    const result = await elicit.url({
+      message: 'Authorize the integration',
+      url: 'https://app.example.com/oauth/github/start',
+    })
+
+    return result.action === 'accept'
+      ? 'GitHub connected.'
+      : `User did not complete the flow (${result.action}).`
+  },
+})
+```
+
+::callout{icon="i-lucide-shield" color="warning"}
+URL-mode elicitation triggers a redirect on the user's machine — only use it for trusted endpoints. The MCP spec recommends pairing it with [origin/scheme validation](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) on your callback.
+::
+
+## Capability Checks
+
+Always handle the case where the client doesn't declare the elicitation capability — many clients (and self-hosted relays) advertise tools without it.
+
+```typescript
+const elicit = useMcpElicitation()
+
+if (!elicit.supports('form')) {
+  return 'This tool needs an interactive client (Cursor, Claude Desktop, …).'
+}
+```
+
+When you call `form()` or `url()` against an unsupported client, the composable throws `McpElicitationError` with `code: 'unsupported'` so you can recover gracefully:
+
+```typescript
+import { McpElicitationError } from '@nuxtjs/mcp-toolkit/server'
+
+try {
+  await elicit.form({ message: '…', schema: { … } })
+}
+catch (err) {
+  if (err instanceof McpElicitationError && err.code === 'unsupported') {
+    return 'Client does not support elicitation — falling back to defaults.'
+  }
+  throw err
+}
+```
+
+## Requirements
+
+::callout{icon="i-lucide-triangle-alert" color="warning"}
+`useMcpElicitation()` requires:
+- `nitro.experimental.asyncContext` set to `true` (default since Nuxt 3.8+)
+- A client that declared the `elicitation` capability during initialization
+::

--- a/apps/docs/skills/manage-mcp/SKILL.md
+++ b/apps/docs/skills/manage-mcp/SKILL.md
@@ -350,6 +350,45 @@ See [detailed middleware guide →](./references/middleware.md)
 
 ---
 
+## Interactive Composables
+
+### `useMcpElicitation()`
+
+Ask the connected client for structured input mid-request, or send the user to a URL.
+
+```typescript
+import { z } from 'zod'
+
+export default defineMcpTool({
+  name: 'create_release',
+  inputSchema: { name: z.string() },
+  handler: async ({ name }) => {
+    const elicit = useMcpElicitation()
+
+    const result = await elicit.form({
+      message: `Pick a channel for "${name}"`,
+      schema: {
+        channel: z.enum(['stable', 'beta']).describe('Release channel'),
+      },
+    })
+
+    if (result.action !== 'accept') return 'Cancelled.'
+    return `Released "${name}" on ${result.content.channel}.`
+  },
+})
+```
+
+- **Form mode**: pass a Zod raw shape, the response is validated and typed.
+- **URL mode**: `elicit.url({ message, url })` — opt-in per spec, gate with `elicit.supports('url')`.
+- **Confirm**: `await elicit.confirm('Continue?')` returns a boolean.
+- **Capability check**: `elicit.supports('form' | 'url')` — always `false` before init completes.
+- **Errors**: catch `McpElicitationError` (`code: 'unsupported' | 'invalid-schema' | 'invalid-response'`) to fall back when the client doesn't support elicitation.
+- Schema must be a **flat object of primitives** (string/number/boolean), enums, or string-enum arrays — nested objects are rejected by the spec.
+
+See [elicitation docs →](https://mcp-toolkit.nuxt.dev/advanced/elicitation)
+
+---
+
 ## Review & Best Practices
 
 ### MCP code review (agents & humans)

--- a/apps/playground/app/composables/mcp-tester.ts
+++ b/apps/playground/app/composables/mcp-tester.ts
@@ -1,0 +1,180 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+
+export type ElicitionMode = 'form' | 'url'
+
+export interface PendingElicit {
+  id: string
+  mode: 'form' | 'url'
+  message: string
+  url?: string
+  requestedSchema?: {
+    properties: Record<string, Record<string, unknown>>
+    required?: string[]
+  }
+  resolve: (response: { action: 'accept' | 'decline' | 'cancel', content?: Record<string, unknown> }) => void
+}
+
+export interface ToolCallEntry {
+  id: string
+  tool: string
+  args: Record<string, unknown>
+  startedAt: number
+  finishedAt?: number
+  result?: unknown
+  error?: string
+}
+
+interface ConnectOptions {
+  elicitation: 'none' | 'form' | 'form+url'
+}
+
+type ToolDescriptor = {
+  name: string
+  description?: string
+  inputSchema?: Record<string, unknown>
+}
+
+const DEFAULT_OPTIONS: ConnectOptions = { elicitation: 'form+url' }
+
+export function useMcpTester() {
+  const status = ref<'idle' | 'connecting' | 'connected' | 'error'>('idle')
+  const errorMessage = ref<string | null>(null)
+  const sessionId = ref<string | null>(null)
+  const tools = ref<ToolDescriptor[]>([])
+  const toolCalls = ref<ToolCallEntry[]>([])
+  const pendingElicit = ref<PendingElicit | null>(null)
+  const options = ref<ConnectOptions>({ ...DEFAULT_OPTIONS })
+
+  let client: Client | null = null
+  let transport: StreamableHTTPClientTransport | null = null
+
+  function reset() {
+    toolCalls.value = []
+    tools.value = []
+    sessionId.value = null
+    pendingElicit.value = null
+    errorMessage.value = null
+  }
+
+  async function disconnect() {
+    if (client) {
+      try {
+        await client.close()
+      }
+      catch {
+        // Already closed / never opened — ignore.
+      }
+    }
+    client = null
+    transport = null
+    status.value = 'idle'
+    reset()
+  }
+
+  async function connect(overrides?: Partial<ConnectOptions>) {
+    if (status.value === 'connecting') return
+    Object.assign(options.value, overrides ?? {})
+    await disconnect()
+    status.value = 'connecting'
+    errorMessage.value = null
+
+    try {
+      const capabilities: Record<string, unknown> = {}
+      if (options.value.elicitation === 'form') capabilities.elicitation = { form: {} }
+      else if (options.value.elicitation === 'form+url') capabilities.elicitation = { form: {}, url: {} }
+
+      client = new Client(
+        { name: 'mcp-toolkit-playground-tester', version: '1.0.0' },
+        { capabilities },
+      )
+
+      if (capabilities.elicitation) {
+        client.setRequestHandler(ElicitRequestSchema, (request) => {
+          return new Promise((resolve) => {
+            const params = request.params as {
+              mode?: 'form' | 'url'
+              message: string
+              url?: string
+              requestedSchema?: PendingElicit['requestedSchema']
+            }
+            pendingElicit.value = {
+              id: crypto.randomUUID(),
+              mode: params.mode ?? 'form',
+              message: params.message,
+              url: params.url,
+              requestedSchema: params.requestedSchema,
+              resolve: (response) => {
+                pendingElicit.value = null
+                resolve(response)
+              },
+            }
+          })
+        })
+      }
+
+      transport = new StreamableHTTPClientTransport(new URL('/mcp', window.location.origin))
+      await client.connect(transport)
+      sessionId.value = transport.sessionId ?? null
+
+      const list = await client.listTools()
+      tools.value = list.tools as ToolDescriptor[]
+      status.value = 'connected'
+    }
+    catch (err) {
+      status.value = 'error'
+      errorMessage.value = err instanceof Error ? err.message : String(err)
+      client = null
+      transport = null
+    }
+  }
+
+  async function callTool(name: string, args: Record<string, unknown>) {
+    if (!client) throw new Error('Not connected')
+    const id = crypto.randomUUID()
+    const entry: ToolCallEntry = {
+      id,
+      tool: name,
+      args,
+      startedAt: Date.now(),
+    }
+    toolCalls.value.unshift(entry)
+
+    try {
+      const result = await client.callTool({ name, arguments: args })
+      entry.result = result
+      entry.finishedAt = Date.now()
+    }
+    catch (err) {
+      entry.error = err instanceof Error ? err.message : String(err)
+      entry.finishedAt = Date.now()
+    }
+
+    toolCalls.value = [...toolCalls.value]
+    return entry
+  }
+
+  function answerElicit(response: { action: 'accept' | 'decline' | 'cancel', content?: Record<string, unknown> }) {
+    pendingElicit.value?.resolve(response)
+  }
+
+  function clearCalls() {
+    toolCalls.value = []
+  }
+
+  return {
+    status,
+    errorMessage,
+    sessionId,
+    tools,
+    toolCalls,
+    pendingElicit,
+    options,
+    connect,
+    disconnect,
+    callTool,
+    answerElicit,
+    clearCalls,
+  }
+}

--- a/apps/playground/app/layouts/default.vue
+++ b/apps/playground/app/layouts/default.vue
@@ -92,6 +92,14 @@ const items = computed(() => ([
               label="API Keys"
               :class="{ 'bg-elevated': $route.path === '/app/api-keys' }"
             />
+            <UButton
+              to="/mcp-test"
+              variant="ghost"
+              color="neutral"
+              size="sm"
+              icon="i-lucide-flask-conical"
+              label="MCP Tester"
+            />
           </nav>
         </div>
 

--- a/apps/playground/app/pages/index.vue
+++ b/apps/playground/app/pages/index.vue
@@ -189,5 +189,15 @@ async function onSignUp(payload: FormSubmitEvent<SignUpSchema>) {
         </template>
       </UTabs>
     </UPageCard>
+
+    <UButton
+      to="/mcp-test"
+      variant="link"
+      color="neutral"
+      icon="i-lucide-flask-conical"
+      size="sm"
+    >
+      Try the MCP test console (no auth required)
+    </UButton>
   </div>
 </template>

--- a/apps/playground/app/pages/mcp-test.vue
+++ b/apps/playground/app/pages/mcp-test.vue
@@ -1,0 +1,455 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: 'auth',
+})
+
+useSeoMeta({
+  title: 'MCP Test Console',
+  description: 'Interactively test elicitation features against the playground MCP server.',
+})
+
+const tester = useMcpTester()
+const formAnswers = ref<Record<string, unknown>>({})
+const toolArgs = ref<Record<string, Record<string, unknown>>>({})
+
+const featuredToolNames = ['release_channel', 'connect_account']
+
+const featuredTools = computed(() => {
+  return featuredToolNames
+    .map(name => tester.tools.value.find(t => t.name === name))
+    .filter(Boolean) as typeof tester.tools.value
+})
+
+const otherTools = computed(() => {
+  return tester.tools.value.filter(t => !featuredToolNames.includes(t.name))
+})
+
+const elicitationOptions = [
+  { label: 'Form mode (default)', value: 'form' },
+  { label: 'Form + URL mode', value: 'form+url' },
+  { label: 'Disabled (refuse all)', value: 'none' },
+] as const
+
+const statusColor = computed(() => {
+  return tester.status.value === 'connected'
+    ? 'success'
+    : tester.status.value === 'connecting'
+      ? 'info'
+      : tester.status.value === 'error' ? 'error' : 'neutral'
+})
+
+interface InputField {
+  key: string
+  type: string
+  enum?: string[]
+  description?: string
+  default?: unknown
+  required: boolean
+}
+
+function getInputFields(tool: { inputSchema?: Record<string, unknown> } | undefined): InputField[] {
+  if (!tool?.inputSchema) return []
+  const schema = tool.inputSchema as { properties?: Record<string, Record<string, unknown>>, required?: string[] }
+  const props = schema.properties ?? {}
+  return Object.entries(props).map(([key, prop]) => ({
+    key,
+    type: String(prop.type ?? 'string'),
+    enum: Array.isArray(prop.enum) ? prop.enum as string[] : undefined,
+    description: prop.description as string | undefined,
+    default: prop.default,
+    required: schema.required?.includes(key) ?? false,
+  }))
+}
+
+function getArgs(toolName: string) {
+  if (!toolArgs.value[toolName]) toolArgs.value[toolName] = {}
+  return toolArgs.value[toolName]!
+}
+
+async function runTool(toolName: string) {
+  const raw = toolArgs.value[toolName] ?? {}
+  const tool = tester.tools.value.find(t => t.name === toolName)
+  const args: Record<string, unknown> = {}
+  for (const field of getInputFields(tool)) {
+    let value = raw[field.key]
+    if (value === '' || value === undefined) {
+      if (field.default !== undefined) value = field.default
+      else continue
+    }
+    if (field.type === 'number' && typeof value === 'string') value = Number(value)
+    if (field.type === 'boolean' && typeof value === 'string') value = value === 'true'
+    args[field.key] = value
+  }
+  await tester.callTool(toolName, args)
+}
+
+watch(() => tester.pendingElicit.value, (next) => {
+  if (next?.mode === 'form' && next.requestedSchema) {
+    const initial: Record<string, unknown> = {}
+    for (const [key, prop] of Object.entries(next.requestedSchema.properties)) {
+      if (prop.default !== undefined) initial[key] = prop.default
+      else if (prop.type === 'boolean') initial[key] = false
+      else if (prop.type === 'string') initial[key] = ''
+    }
+    formAnswers.value = initial
+  }
+  else {
+    formAnswers.value = {}
+  }
+})
+
+function formatResult(entry: typeof tester.toolCalls.value[number]) {
+  if (entry.error) return entry.error
+  const result = entry.result as { content?: Array<{ type: string, text?: string }> } | undefined
+  const text = result?.content?.find(c => c.type === 'text')?.text
+  if (text) return text
+  return JSON.stringify(entry.result, null, 2)
+}
+
+function formatTime(ts: number) {
+  return new Date(ts).toLocaleTimeString()
+}
+
+onMounted(() => {
+  tester.connect()
+})
+
+onBeforeUnmount(() => {
+  tester.disconnect()
+})
+</script>
+
+<template>
+  <UApp>
+    <div class="min-h-dvh bg-default">
+      <header class="sticky top-0 z-50 border-b border-default bg-elevated/80 backdrop-blur">
+        <div class="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+          <div class="flex items-center gap-2">
+            <UIcon
+              name="i-lucide-flask-conical"
+              class="size-5 text-primary"
+            />
+            <h1 class="text-lg font-semibold">
+              MCP Test Console
+            </h1>
+            <UBadge
+              :color="statusColor"
+              variant="subtle"
+              size="sm"
+            >
+              {{ tester.status.value }}
+            </UBadge>
+          </div>
+          <div class="flex items-center gap-2">
+            <UButton
+              variant="ghost"
+              color="neutral"
+              icon="i-lucide-rotate-ccw"
+              size="sm"
+              :loading="tester.status.value === 'connecting'"
+              @click="tester.connect()"
+            >
+              Reconnect
+            </UButton>
+            <UButton
+              to="/app"
+              variant="ghost"
+              color="neutral"
+              size="sm"
+              icon="i-lucide-arrow-left"
+            >
+              Back to app
+            </UButton>
+          </div>
+        </div>
+      </header>
+
+      <main class="mx-auto max-w-6xl space-y-6 p-4 lg:p-6">
+        <UAlert
+          v-if="tester.errorMessage.value"
+          color="error"
+          variant="subtle"
+          icon="i-lucide-octagon-alert"
+          :title="tester.errorMessage.value"
+        />
+
+        <UCard>
+          <template #header>
+            <div class="flex items-center justify-between gap-4">
+              <h2 class="font-semibold">
+                Connection
+              </h2>
+              <span
+                v-if="tester.sessionId.value"
+                class="text-xs font-mono text-muted truncate max-w-xs"
+                :title="tester.sessionId.value"
+              >
+                session: {{ tester.sessionId.value }}
+              </span>
+            </div>
+          </template>
+
+          <UFormField
+            label="Elicitation capability"
+            hint="Switch to test how tools react when the client supports different modes."
+          >
+            <USelect
+              :model-value="tester.options.value.elicitation"
+              :items="[...elicitationOptions]"
+              class="w-full sm:max-w-sm"
+              @update:model-value="(value: string) => tester.connect({ elicitation: value as 'none' | 'form' | 'form+url' })"
+            />
+          </UFormField>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="font-semibold">
+              Featured demo tools
+            </h2>
+          </template>
+
+          <div class="grid gap-4 lg:grid-cols-2">
+            <UCard
+              v-for="tool in featuredTools"
+              :key="tool.name"
+              variant="subtle"
+            >
+              <div class="flex flex-col gap-3">
+                <div>
+                  <div class="font-mono text-sm font-semibold">
+                    {{ tool.name }}
+                  </div>
+                  <p class="mt-1 text-sm text-muted">
+                    {{ tool.description }}
+                  </p>
+                </div>
+
+                <div
+                  v-for="field in getInputFields(tool)"
+                  :key="field.key"
+                  class="flex flex-col gap-1"
+                >
+                  <label class="text-xs font-medium text-muted">{{ field.key }}<span
+                    v-if="field.required"
+                    class="text-error"
+                  >*</span></label>
+                  <USelect
+                    v-if="field.enum"
+                    :model-value="getArgs(tool.name)[field.key] as string"
+                    :items="field.enum.map(v => ({ label: v, value: v }))"
+                    :placeholder="field.description ?? ''"
+                    class="w-full"
+                    @update:model-value="(v: string) => getArgs(tool.name)[field.key] = v"
+                  />
+                  <UCheckbox
+                    v-else-if="field.type === 'boolean'"
+                    :model-value="!!getArgs(tool.name)[field.key]"
+                    :label="field.description ?? field.key"
+                    @update:model-value="(v: boolean | 'indeterminate') => getArgs(tool.name)[field.key] = v === true"
+                  />
+                  <UInput
+                    v-else
+                    :model-value="getArgs(tool.name)[field.key] as string"
+                    :type="field.type === 'number' ? 'number' : 'text'"
+                    :placeholder="field.description ?? ''"
+                    class="w-full"
+                    @update:model-value="(v: string | number) => getArgs(tool.name)[field.key] = v"
+                  />
+                </div>
+
+                <UButton
+                  block
+                  icon="i-lucide-play"
+                  :disabled="tester.status.value !== 'connected'"
+                  @click="runTool(tool.name)"
+                >
+                  Run
+                </UButton>
+              </div>
+            </UCard>
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <div class="flex items-center justify-between">
+              <h2 class="font-semibold">
+                Tool calls
+              </h2>
+              <UButton
+                size="xs"
+                color="neutral"
+                variant="ghost"
+                icon="i-lucide-trash-2"
+                @click="tester.clearCalls()"
+              >
+                Clear
+              </UButton>
+            </div>
+          </template>
+          <div
+            v-if="tester.toolCalls.value.length === 0"
+            class="py-8 text-center text-sm text-muted"
+          >
+            No calls yet. Pick a tool above and hit Run.
+          </div>
+          <ul class="space-y-3">
+            <li
+              v-for="entry in tester.toolCalls.value"
+              :key="entry.id"
+              class="rounded-md border border-default bg-elevated/40 p-3"
+            >
+              <div class="flex items-center justify-between gap-2">
+                <span class="font-mono text-xs font-semibold">{{ entry.tool }}</span>
+                <span class="text-[10px] uppercase text-dimmed">{{ formatTime(entry.startedAt) }}</span>
+              </div>
+              <pre
+                v-if="Object.keys(entry.args).length"
+                class="mt-2 overflow-x-auto rounded bg-default/60 p-2 text-[11px]"
+              >{{ JSON.stringify(entry.args) }}</pre>
+              <div
+                v-if="entry.finishedAt"
+                class="mt-2 whitespace-pre-wrap rounded text-xs"
+                :class="entry.error ? 'text-error' : 'text-default'"
+              >
+                {{ formatResult(entry) }}
+              </div>
+              <UBadge
+                v-else
+                color="warning"
+                variant="subtle"
+                size="xs"
+                icon="i-lucide-loader"
+                class="mt-2"
+              >
+                pending
+              </UBadge>
+            </li>
+          </ul>
+        </UCard>
+
+        <UCard v-if="otherTools.length">
+          <template #header>
+            <h2 class="font-semibold">
+              All other tools
+              <span class="text-xs font-normal text-muted">({{ otherTools.length }})</span>
+            </h2>
+          </template>
+          <div class="flex flex-wrap gap-2">
+            <UBadge
+              v-for="tool in otherTools"
+              :key="tool.name"
+              variant="subtle"
+              color="neutral"
+              :title="tool.description"
+            >
+              {{ tool.name }}
+            </UBadge>
+          </div>
+        </UCard>
+      </main>
+
+      <UModal
+        :open="!!tester.pendingElicit.value"
+        :dismissible="false"
+        :ui="{ content: 'sm:max-w-lg' }"
+      >
+        <template #content>
+          <div
+            v-if="tester.pendingElicit.value"
+            class="flex flex-col gap-5 p-5 sm:p-6"
+          >
+            <div class="flex items-center gap-2">
+              <UIcon
+                :name="tester.pendingElicit.value.mode === 'url' ? 'i-lucide-external-link' : 'i-lucide-message-square-quote'"
+                class="size-5 text-primary"
+              />
+              <h3 class="font-semibold">
+                {{ tester.pendingElicit.value.mode === 'url' ? 'URL elicitation' : 'Form elicitation' }}
+              </h3>
+            </div>
+
+            <p class="text-sm text-default">
+              {{ tester.pendingElicit.value.message }}
+            </p>
+
+            <div
+              v-if="tester.pendingElicit.value.mode === 'url'"
+              class="rounded-md border border-default bg-elevated/40 p-3 text-sm"
+            >
+              <div class="text-xs uppercase tracking-wide text-dimmed">
+                URL
+              </div>
+              <a
+                class="mt-1 block break-all font-mono text-primary hover:underline"
+                target="_blank"
+                rel="noopener"
+                :href="tester.pendingElicit.value.url"
+              >{{ tester.pendingElicit.value.url }}</a>
+            </div>
+
+            <form
+              v-else-if="tester.pendingElicit.value.requestedSchema"
+              class="flex flex-col gap-4"
+            >
+              <UFormField
+                v-for="(prop, key) in tester.pendingElicit.value.requestedSchema.properties"
+                :key="key"
+                :label="(prop.title as string) ?? key"
+                :hint="(prop.description as string) ?? ''"
+                :required="tester.pendingElicit.value.requestedSchema.required?.includes(key) ?? false"
+              >
+                <USelect
+                  v-if="Array.isArray(prop.enum)"
+                  :model-value="formAnswers[key] as string"
+                  :items="(prop.enum as string[]).map(v => ({ label: v, value: v }))"
+                  class="w-full"
+                  @update:model-value="(v: string) => formAnswers[key] = v"
+                />
+                <UCheckbox
+                  v-else-if="prop.type === 'boolean'"
+                  :model-value="!!formAnswers[key]"
+                  @update:model-value="(v: boolean | 'indeterminate') => formAnswers[key] = v === true"
+                />
+                <UInput
+                  v-else
+                  :model-value="formAnswers[key] as string"
+                  :type="prop.type === 'number' || prop.type === 'integer' ? 'number' : 'text'"
+                  class="w-full"
+                  @update:model-value="(v: string | number) => formAnswers[key] = v"
+                />
+              </UFormField>
+            </form>
+
+            <div class="flex flex-wrap justify-end gap-2 border-t border-default pt-4">
+              <UButton
+                color="neutral"
+                variant="ghost"
+                @click="tester.answerElicit({ action: 'cancel' })"
+              >
+                Cancel
+              </UButton>
+              <UButton
+                color="neutral"
+                variant="subtle"
+                @click="tester.answerElicit({ action: 'decline' })"
+              >
+                Decline
+              </UButton>
+              <UButton
+                color="primary"
+                @click="tester.answerElicit({
+                  action: 'accept',
+                  content: tester.pendingElicit.value.mode === 'form' ? formAnswers : undefined,
+                })"
+              >
+                Accept
+              </UButton>
+            </div>
+          </div>
+        </template>
+      </UModal>
+    </div>
+  </UApp>
+</template>

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -23,6 +23,7 @@
     "@ai-sdk/mcp": "^1.0.36",
     "@better-auth/api-key": "^1.6.5",
     "@electric-sql/pglite": "^0.4.4",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@nuxt/ui": "^4.6.1",
     "@nuxthub/core": "^0.10.7",
     "@nuxtjs/mcp-toolkit": "workspace:*",

--- a/apps/playground/server/mcp/tools/connect-account.ts
+++ b/apps/playground/server/mcp/tools/connect-account.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+
+export default defineMcpTool({
+  name: 'connect_account',
+  description: 'Demo URL-mode elicitation: redirect the user to an external auth page',
+  inputSchema: {
+    provider: z.enum(['github', 'google', 'gitlab']).default('github').describe('Provider to connect'),
+  },
+  handler: async ({ provider }) => {
+    const elicit = useMcpElicitation()
+
+    if (!elicit.supports('url')) {
+      return `Open https://example.com/oauth/${provider} to connect, then try again. (Client did not declare elicitation.url.)`
+    }
+
+    const result = await elicit.url({
+      message: `Authorize the ${provider} integration`,
+      url: `https://example.com/oauth/${provider}/start`,
+    })
+
+    return result.action === 'accept'
+      ? `${provider} connected.`
+      : `User did not complete the ${provider} flow (${result.action}).`
+  },
+})

--- a/apps/playground/server/mcp/tools/release-channel.ts
+++ b/apps/playground/server/mcp/tools/release-channel.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+export default defineMcpTool({
+  name: 'release_channel',
+  description: 'Demo elicitation: ask the user which release channel to publish to',
+  inputSchema: {
+    name: z.string().describe('Release name'),
+  },
+  handler: async ({ name }) => {
+    const elicit = useMcpElicitation()
+
+    if (!elicit.supports('form')) {
+      return `Use a client that supports elicitation to publish "${name}".`
+    }
+
+    const result = await elicit.form({
+      message: `Pick a release channel for "${name}"`,
+      schema: {
+        channel: z.enum(['stable', 'beta', 'canary']).describe('Release channel'),
+        notify: z.boolean().default(true).describe('Notify subscribers'),
+      },
+    })
+
+    if (result.action !== 'accept') {
+      return `Release "${name}" cancelled (${result.action}).`
+    }
+
+    return `Released "${name}" on ${result.content.channel} (notify=${result.content.notify}).`
+  },
+})

--- a/packages/nuxt-mcp-toolkit/src/module.ts
+++ b/packages/nuxt-mcp-toolkit/src/module.ts
@@ -295,6 +295,7 @@ export default defineNuxtModule<ModuleOptions>({
     const mcpDefinitionsPath = resolver.resolve('runtime/server/mcp/definitions')
     const mcpSessionPath = resolver.resolve('runtime/server/mcp/session')
     const mcpServerPath = resolver.resolve('runtime/server/mcp/server')
+    const mcpElicitationPath = resolver.resolve('runtime/server/mcp/elicitation')
 
     if (options.autoImports !== false) {
       addServerImports([
@@ -322,6 +323,8 @@ export default defineNuxtModule<ModuleOptions>({
         { name: 'useMcpSession', from: mcpSessionPath },
         { name: 'invalidateMcpSession', from: mcpSessionPath },
         { name: 'useMcpServer', from: mcpServerPath },
+        { name: 'useMcpElicitation', from: mcpElicitationPath },
+        { name: 'McpElicitationError', from: mcpElicitationPath },
       ])
     }
 

--- a/packages/nuxt-mcp-toolkit/src/module.ts
+++ b/packages/nuxt-mcp-toolkit/src/module.ts
@@ -324,7 +324,6 @@ export default defineNuxtModule<ModuleOptions>({
         { name: 'invalidateMcpSession', from: mcpSessionPath },
         { name: 'useMcpServer', from: mcpServerPath },
         { name: 'useMcpElicitation', from: mcpElicitationPath },
-        { name: 'McpElicitationError', from: mcpElicitationPath },
       ])
     }
 

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/index.ts
@@ -8,6 +8,22 @@ export * from './results'
 export * from './extract-tool-names'
 export { completable } from '@modelcontextprotocol/sdk/server/completable.js'
 
+export { useMcpServer } from '../server'
+export type { McpServerHelper } from '../server'
+
+export { useMcpSession, invalidateMcpSession } from '../session'
+export type { McpSessionStore } from '../session'
+
+export { useMcpElicitation, McpElicitationError } from '../elicitation'
+export type {
+  ElicitationFormParams,
+  ElicitationFormResult,
+  ElicitationMode,
+  ElicitationUrlParams,
+  ElicitationUrlResult,
+  McpElicitation,
+} from '../elicitation'
+
 /** Commonly used MCP protocol types from `@modelcontextprotocol/sdk` (single import path with the toolkit). */
 export type {
   Annotations,

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/devtools/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/devtools/index.ts
@@ -8,7 +8,10 @@ import type { ChildProcess } from 'node:child_process'
 const log = logger.withTag('@nuxtjs/mcp-toolkit')
 
 // Constants
-const INSPECTOR_TIMEOUT = 15000
+// First-run npx may need to download the inspector (~50MB) before starting; the
+// 60s ceiling covers cold starts on slow networks while the on-demand health
+// check resolves immediately once the inspector is ready.
+const INSPECTOR_TIMEOUT = 60000
 const HEALTH_CHECK_TIMEOUT = 3000
 const INSPECTOR_DEFAULT_CLIENT_PORT = 6274
 const INSPECTOR_DEFAULT_SERVER_PORT = 6277
@@ -46,8 +49,14 @@ function buildInspectorUrl(baseUrl: string, mcpServerUrl: string): string {
 }
 
 function extractProxyToken(text: string): string | null {
-  const match = text.match(/Session token:\s+([a-f0-9]+)/i)
-  return match?.[1] ?? null
+  // The MCP Inspector emits the token in two distinct places depending on
+  // version: `Session token: <hex>` and the pre-filled URL on the
+  // `🔗 Open inspector with token pre-filled: …?MCP_PROXY_AUTH_TOKEN=<hex>`
+  // line. Either is enough to authenticate the iframe embed.
+  const sessionMatch = text.match(/Session token:\s+([a-f0-9]+)/i)
+  if (sessionMatch?.[1]) return sessionMatch[1]
+  const urlMatch = text.match(/MCP_PROXY_AUTH_TOKEN=([a-f0-9]+)/i)
+  return urlMatch?.[1] ?? null
 }
 
 function limitBuffer(buffer: string, maxSize: number): string {
@@ -220,6 +229,17 @@ async function launchMcpInspector(nuxt: Nuxt, options: ModuleOptions): Promise<v
             if (token) {
               proxyAuthToken = token
             }
+          }
+
+          // Fast path: the inspector prints "🔗 Open inspector with token
+          // pre-filled: http://localhost:6274/?MCP_PROXY_AUTH_TOKEN=…" once
+          // it is fully ready. We only short-circuit the polling delay when
+          // the token has already been captured, otherwise we'd hand
+          // DevTools an iframe URL the inspector rejects as unauthenticated.
+          if (!isResolved && proxyAuthToken && /Open inspector with token|MCP Inspector .*running/i.test(stdoutBuffer)) {
+            isResolved = true
+            log.success(`✅ MCP Inspector is ready at ${inspectorBaseUrl}`)
+            handleUrlDetected(inspectorBaseUrl, mcpServerUrl, timeoutId, resolve)
           }
         },
         stderr: (data: Buffer) => {

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/elicitation.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/elicitation.ts
@@ -1,0 +1,277 @@
+import type { ZodRawShape } from 'zod'
+import { z } from 'zod'
+import type { ShapeOutput } from '@modelcontextprotocol/sdk/server/zod-compat.js'
+import type {
+  ElicitRequestFormParams,
+  ElicitRequestURLParams,
+  ElicitResult,
+} from '@modelcontextprotocol/sdk/types.js'
+import { useMcpServer } from './server'
+
+/**
+ * Restricted JSON Schema property allowed by the MCP elicitation spec.
+ * Only flat objects with primitive properties (or single-/multi-select enums) are accepted.
+ */
+type ElicitationPrimitiveSchema = Record<string, unknown>
+
+interface ElicitationRequestedSchema {
+  type: 'object'
+  properties: Record<string, ElicitationPrimitiveSchema>
+  required?: string[]
+}
+
+/**
+ * Parameters for a form-mode elicitation request.
+ *
+ * The schema is provided as a Zod raw shape (matching `defineMcpTool`'s `inputSchema`).
+ * It must produce a flat object with primitive properties — strings, numbers, booleans,
+ * and single- or multi-select enums. Nested objects and arrays of objects are not
+ * supported by the MCP spec and will throw.
+ */
+export interface ElicitationFormParams<S extends ZodRawShape> {
+  /** Human-readable message displayed to the user. */
+  message: string
+  /** Zod raw shape describing the structured input the server is asking for. */
+  schema: S
+}
+
+/**
+ * Parameters for a URL-mode elicitation request.
+ *
+ * Use this for sensitive interactions that require redirecting the user to an
+ * external page (auth flows, payment, account verification, …).
+ */
+export interface ElicitationUrlParams {
+  /** Human-readable message displayed to the user before opening the URL. */
+  message: string
+  /** External URL the user should be redirected to. */
+  url: string
+}
+
+export interface ElicitationFormResult<S extends ZodRawShape> {
+  /** What the user did with the elicitation request. */
+  action: 'accept' | 'decline' | 'cancel'
+  /** The validated payload, present only when `action === 'accept'`. */
+  content?: ShapeOutput<S>
+}
+
+export interface ElicitationUrlResult {
+  /** What the user did with the elicitation request. */
+  action: 'accept' | 'decline' | 'cancel'
+}
+
+/**
+ * Mode-aware capability check.
+ *
+ * `'form'` is the default elicitation mode (always advertised when the client
+ * declares `elicitation`); `'url'` is opt-in per spec 2025-11-25.
+ */
+export type ElicitationMode = 'form' | 'url'
+
+/**
+ * Error thrown by the elicitation composable when the request cannot be made
+ * (capability missing, schema invalid, response shape unexpected, …).
+ *
+ * Catchable from inside tool/prompt/resource handlers to fall back to other
+ * code paths.
+ */
+export class McpElicitationError extends Error {
+  constructor(message: string, public readonly code: 'unsupported' | 'invalid-schema' | 'invalid-response') {
+    super(message)
+    this.name = 'McpElicitationError'
+  }
+}
+
+export interface McpElicitation {
+  /**
+   * Ask the user for structured input via a form (default mode).
+   *
+   * The Zod shape is converted to the spec-restricted JSON Schema and the
+   * client's response is validated against it before being returned.
+   *
+   * Throws `McpElicitationError('unsupported')` when the connected client did
+   * not declare `elicitation` in its capabilities.
+   */
+  form<S extends ZodRawShape>(params: ElicitationFormParams<S>): Promise<ElicitationFormResult<S>>
+  /**
+   * Direct the user to an external URL (URL mode, MCP spec 2025-11-25).
+   *
+   * Throws `McpElicitationError('unsupported')` when the client did not
+   * declare `elicitation.url` in its capabilities.
+   */
+  url(params: ElicitationUrlParams): Promise<ElicitationUrlResult>
+  /**
+   * Convenience yes/no prompt that resolves to `true` only when the user
+   * accepts and confirms.
+   */
+  confirm(message: string): Promise<boolean>
+  /**
+   * Returns true when the connected client supports the given mode.
+   *
+   * Always false before the client's `initialize` round-trip completes.
+   */
+  supports(mode?: ElicitationMode): boolean
+}
+
+const PRIMITIVE_TYPES = new Set(['string', 'number', 'integer', 'boolean'])
+
+function isPrimitiveLeaf(node: Record<string, unknown>): boolean {
+  if (typeof node.type === 'string' && PRIMITIVE_TYPES.has(node.type)) return true
+  if (Array.isArray(node.enum) && node.enum.every(v => typeof v === 'string')) return true
+  return false
+}
+
+function flattenProperty(prop: Record<string, unknown>, key: string): ElicitationPrimitiveSchema {
+  // Strip JSON Schema metadata that the spec rejects.
+  const { $schema: _$schema, additionalProperties: _add, ...rest } = prop
+
+  if (rest.type === 'array') {
+    const items = rest.items as Record<string, unknown> | undefined
+    if (!items || !isPrimitiveLeaf(items) || items.type !== 'string' || !Array.isArray(items.enum)) {
+      throw new McpElicitationError(
+        `Field "${key}" uses an array type that the MCP elicitation spec does not allow. `
+        + 'Only arrays of string enums (multi-select) are supported.',
+        'invalid-schema',
+      )
+    }
+    return rest
+  }
+
+  if (!isPrimitiveLeaf(rest)) {
+    throw new McpElicitationError(
+      `Field "${key}" uses a type that the MCP elicitation spec does not allow `
+      + '(only flat objects with primitive properties, enums, or string-enum arrays are accepted).',
+      'invalid-schema',
+    )
+  }
+
+  return rest
+}
+
+function shapeToRequestedSchema<S extends ZodRawShape>(shape: S): ElicitationRequestedSchema {
+  const objectSchema = z.object(shape)
+  const json = z.toJSONSchema(objectSchema, { unrepresentable: 'any' }) as {
+    properties?: Record<string, Record<string, unknown>>
+    required?: string[]
+  }
+
+  const properties = json.properties ?? {}
+  const required = json.required ?? []
+
+  const flatProps: Record<string, ElicitationPrimitiveSchema> = {}
+  for (const [key, prop] of Object.entries(properties)) {
+    flatProps[key] = flattenProperty(prop, key)
+  }
+
+  const result: ElicitationRequestedSchema = {
+    type: 'object',
+    properties: flatProps,
+  }
+  if (required.length > 0) result.required = required
+  return result
+}
+
+function clientSupports(capabilities: { elicitation?: Record<string, unknown> } | undefined, mode: ElicitationMode): boolean {
+  const elicitation = capabilities?.elicitation
+  if (!elicitation) return false
+  const hasForm = (elicitation as Record<string, unknown>).form !== undefined
+  const hasUrl = (elicitation as Record<string, unknown>).url !== undefined
+  if (mode === 'url') return hasUrl
+  // Per MCP spec 2025-11-25: an empty `elicitation: {}` capability defaults
+  // to form mode for backwards compatibility, otherwise form must be declared
+  // explicitly when other modes (like `url`) are present.
+  return hasForm || (!hasForm && !hasUrl)
+}
+
+/**
+ * Returns an elicitation helper bound to the current MCP request.
+ *
+ * Must be called inside an MCP tool, resource, or prompt handler. Requires
+ * `nitro.experimental.asyncContext: true` (same constraint as `useMcpServer`).
+ *
+ * @example
+ * ```ts
+ * const result = await useMcpElicitation().form({
+ *   message: 'Pick a release channel',
+ *   schema: { channel: z.enum(['stable', 'beta']) },
+ * })
+ * if (result.action === 'accept') {
+ *   // result.content.channel is type-safe ('stable' | 'beta')
+ * }
+ * ```
+ */
+export function useMcpElicitation(): McpElicitation {
+  const helper = useMcpServer()
+  // The high-level `McpServer` exposes the underlying SDK `Server` via `.server`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sdkServer = (helper.server as any).server as {
+    elicitInput: (params: ElicitRequestFormParams | ElicitRequestURLParams) => Promise<ElicitResult>
+    getClientCapabilities: () => { elicitation?: Record<string, unknown> } | undefined
+  }
+
+  function supports(mode: ElicitationMode = 'form'): boolean {
+    return clientSupports(sdkServer.getClientCapabilities(), mode)
+  }
+
+  async function form<S extends ZodRawShape>(params: ElicitationFormParams<S>): Promise<ElicitationFormResult<S>> {
+    if (!supports('form')) {
+      throw new McpElicitationError(
+        'Client does not support elicitation (mode=form). The connected client did not declare the `elicitation` capability during initialization.',
+        'unsupported',
+      )
+    }
+
+    const requestedSchema = shapeToRequestedSchema(params.schema)
+
+    const result = await sdkServer.elicitInput({
+      mode: 'form',
+      message: params.message,
+      requestedSchema,
+    } as ElicitRequestFormParams)
+
+    if (result.action !== 'accept') {
+      return { action: result.action }
+    }
+
+    const parsed = z.object(params.schema).safeParse(result.content ?? {})
+    if (!parsed.success) {
+      throw new McpElicitationError(
+        `Client returned a payload that does not match the requested schema: ${parsed.error.message}`,
+        'invalid-response',
+      )
+    }
+
+    return { action: 'accept', content: parsed.data as ShapeOutput<S> }
+  }
+
+  async function url(params: ElicitationUrlParams): Promise<ElicitationUrlResult> {
+    if (!supports('url')) {
+      throw new McpElicitationError(
+        'Client does not support elicitation (mode=url). URL-mode elicitation is opt-in per the MCP spec; the connected client did not declare `elicitation.url`.',
+        'unsupported',
+      )
+    }
+
+    const result = await sdkServer.elicitInput({
+      mode: 'url',
+      message: params.message,
+      url: params.url,
+      // The SDK populates `elicitationId` itself when the field is missing.
+      elicitationId: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`,
+    } as ElicitRequestURLParams)
+
+    return { action: result.action }
+  }
+
+  async function confirm(message: string): Promise<boolean> {
+    const result = await form({
+      message,
+      schema: {
+        confirm: z.boolean().describe('Confirm the action').default(false),
+      },
+    })
+    return result.action === 'accept' && result.content?.confirm === true
+  }
+
+  return { form, url, confirm, supports }
+}

--- a/packages/nuxt-mcp-toolkit/test/elicitation.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/elicitation.test.ts
@@ -1,0 +1,201 @@
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect, afterAll } from 'vitest'
+import { setup, url } from '@nuxt/test-utils/e2e'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+
+function createMcpUrl(path = '/mcp') {
+  const baseUrl = url('/')
+  const baseUrlObj = new URL(baseUrl)
+  const origin = `${baseUrlObj.protocol}//${baseUrlObj.host}`
+  return new URL(path, origin)
+}
+
+type ElicitResponder = (params: { mode?: string, message: string, url?: string }) => {
+  action: 'accept' | 'decline' | 'cancel'
+  content?: Record<string, unknown>
+}
+
+interface ConnectedClient {
+  client: Client
+  responses: Array<unknown>
+  setResponder: (fn: ElicitResponder) => void
+}
+
+async function createElicitClient(opts: {
+  capabilities?: Record<string, unknown>
+  initialResponder?: ElicitResponder
+} = {}): Promise<ConnectedClient> {
+  const responses: Array<unknown> = []
+  let responder: ElicitResponder | null = opts.initialResponder ?? null
+
+  const client = new Client(
+    { name: 'elicit-test-client', version: '1.0.0' },
+    { capabilities: opts.capabilities },
+  )
+
+  if (opts.capabilities?.elicitation) {
+    client.setRequestHandler(ElicitRequestSchema, async (request) => {
+      responses.push(request.params)
+      if (!responder) {
+        return { action: 'cancel' as const }
+      }
+      const out = responder(request.params as { mode?: string, message: string, url?: string })
+      return out
+    })
+  }
+
+  await client.connect(new StreamableHTTPClientTransport(createMcpUrl()))
+
+  return {
+    client,
+    responses,
+    setResponder(fn) {
+      responder = fn
+    },
+  }
+}
+
+function readText(result: unknown): string {
+  const content = (result as { content: Array<{ type: string, text?: string }> }).content
+  const text = content.find(c => c.type === 'text')?.text
+  if (!text) throw new Error('expected text content')
+  return text
+}
+
+describe('useMcpElicitation', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/elicitation', import.meta.url)),
+  })
+
+  const opened: Client[] = []
+
+  afterAll(async () => {
+    for (const c of opened) {
+      try {
+        await c.close()
+      }
+      catch {
+        // Ignore close errors — the test process is exiting anyway.
+      }
+    }
+  })
+
+  it('reports the modes declared by the connected client via supports()', async () => {
+    // Empty `elicitation: {}` is normalized by the SDK to `{ form: {} }` for backwards compat.
+    const a = await createElicitClient({ capabilities: { elicitation: {} } })
+    opened.push(a.client)
+    const result = await a.client.callTool({ name: 'supports_check', arguments: {} })
+    expect(JSON.parse(readText(result))).toEqual({ form: true, url: false })
+
+    // When other modes are declared, `form` must be opted in explicitly per MCP spec 2025-11-25.
+    const b = await createElicitClient({ capabilities: { elicitation: { form: {}, url: {} } } })
+    opened.push(b.client)
+    const result2 = await b.client.callTool({ name: 'supports_check', arguments: {} })
+    expect(JSON.parse(readText(result2))).toEqual({ form: true, url: true })
+
+    const c = await createElicitClient({ capabilities: { elicitation: { url: {} } } })
+    opened.push(c.client)
+    const result3 = await c.client.callTool({ name: 'supports_check', arguments: {} })
+    expect(JSON.parse(readText(result3))).toEqual({ form: false, url: true })
+
+    const d = await createElicitClient({ capabilities: {} })
+    opened.push(d.client)
+    const result4 = await d.client.callTool({ name: 'supports_check', arguments: {} })
+    expect(JSON.parse(readText(result4))).toEqual({ form: false, url: false })
+  })
+
+  it('form() validates the response against the requested Zod shape', async () => {
+    const conn = await createElicitClient({
+      capabilities: { elicitation: {} },
+      initialResponder: () => ({
+        action: 'accept',
+        content: { name: 'Ada', channel: 'stable' },
+      }),
+    })
+    opened.push(conn.client)
+
+    const result = await conn.client.callTool({ name: 'ask_form', arguments: {} })
+    const parsed = JSON.parse(readText(result))
+
+    expect(parsed.action).toBe('accept')
+    expect(parsed.content).toEqual({ name: 'Ada', channel: 'stable' })
+
+    expect(conn.responses).toHaveLength(1)
+    const params = conn.responses[0] as { mode?: string, requestedSchema: { properties: Record<string, unknown> } }
+    expect(params.mode).toBe('form')
+    expect(Object.keys(params.requestedSchema.properties).sort()).toEqual(['channel', 'name'])
+  })
+
+  it('form() returns the action without content when the user declines', async () => {
+    const conn = await createElicitClient({
+      capabilities: { elicitation: {} },
+      initialResponder: () => ({ action: 'decline' }),
+    })
+    opened.push(conn.client)
+
+    const result = await conn.client.callTool({ name: 'ask_form', arguments: {} })
+    const parsed = JSON.parse(readText(result))
+
+    expect(parsed).toEqual({ action: 'decline' })
+  })
+
+  it('form() throws McpElicitationError when the client did not declare elicitation', async () => {
+    const conn = await createElicitClient({ capabilities: {} })
+    opened.push(conn.client)
+
+    const result = await conn.client.callTool({ name: 'ask_form', arguments: {} })
+    const parsed = JSON.parse(readText(result))
+
+    expect(parsed).toEqual({ error: 'unsupported' })
+  })
+
+  it('url() succeeds when the client declares elicitation.url', async () => {
+    const conn = await createElicitClient({
+      capabilities: { elicitation: { url: {} } },
+      initialResponder: () => ({ action: 'accept' }),
+    })
+    opened.push(conn.client)
+
+    const result = await conn.client.callTool({ name: 'ask_url', arguments: {} })
+    const parsed = JSON.parse(readText(result))
+
+    expect(parsed).toEqual({ action: 'accept' })
+
+    const params = conn.responses[0] as { mode?: string, url?: string }
+    expect(params.mode).toBe('url')
+    expect(params.url).toBe('https://example.com/verify')
+  })
+
+  it('url() throws McpElicitationError when the client only declares form mode', async () => {
+    const conn = await createElicitClient({
+      capabilities: { elicitation: {} },
+      initialResponder: () => ({ action: 'accept' }),
+    })
+    opened.push(conn.client)
+
+    const result = await conn.client.callTool({ name: 'ask_url', arguments: {} })
+    const parsed = JSON.parse(readText(result))
+
+    expect(parsed).toEqual({ error: 'unsupported' })
+  })
+
+  it('confirm() returns true only when the user accepts with confirm=true', async () => {
+    const accepting = await createElicitClient({
+      capabilities: { elicitation: {} },
+      initialResponder: () => ({ action: 'accept', content: { confirm: true } }),
+    })
+    opened.push(accepting.client)
+    const acceptResult = await accepting.client.callTool({ name: 'ask_confirm', arguments: {} })
+    expect(readText(acceptResult)).toBe('yes')
+
+    const declining = await createElicitClient({
+      capabilities: { elicitation: {} },
+      initialResponder: () => ({ action: 'accept', content: { confirm: false } }),
+    })
+    opened.push(declining.client)
+    const declineResult = await declining.client.callTool({ name: 'ask_confirm', arguments: {} })
+    expect(readText(declineResult)).toBe('no')
+  })
+})

--- a/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/app.vue
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/app.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>elicitation</div>
+</template>
+
+<script setup>
+</script>

--- a/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/nuxt.config.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/nuxt.config.ts
@@ -1,0 +1,15 @@
+import MyModule from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    MyModule,
+  ],
+  nitro: {
+    experimental: {
+      asyncContext: true,
+    },
+  },
+  mcp: {
+    sessions: true,
+  },
+})

--- a/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/package.json
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "mcp-toolkit-elicitation-fixture",
+  "private": true
+}

--- a/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/server/mcp/tools/ask-confirm.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/server/mcp/tools/ask-confirm.ts
@@ -1,0 +1,24 @@
+import { defineMcpTool } from '../../../../../../src/runtime/server/types'
+import { useMcpElicitation, McpElicitationError } from '../../../../../../src/runtime/server/mcp/elicitation'
+
+export default defineMcpTool({
+  name: 'ask_confirm',
+  description: 'Ask the user to confirm an action',
+  inputSchema: {},
+  handler: async () => {
+    const elicit = useMcpElicitation()
+
+    try {
+      const ok = await elicit.confirm('Continue?')
+      return { content: [{ type: 'text', text: ok ? 'yes' : 'no' }] }
+    }
+    catch (err) {
+      if (err instanceof McpElicitationError) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: err.code }) }],
+        }
+      }
+      throw err
+    }
+  },
+})

--- a/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/server/mcp/tools/ask-form.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/server/mcp/tools/ask-form.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+import { defineMcpTool } from '../../../../../../src/runtime/server/types'
+import { useMcpElicitation, McpElicitationError } from '../../../../../../src/runtime/server/mcp/elicitation'
+
+export default defineMcpTool({
+  name: 'ask_form',
+  description: 'Ask the user for a name and channel via form-mode elicitation',
+  inputSchema: {},
+  handler: async () => {
+    const elicit = useMcpElicitation()
+
+    try {
+      const result = await elicit.form({
+        message: 'Please provide your details',
+        schema: {
+          name: z.string().describe('Your name'),
+          channel: z.enum(['stable', 'beta']).describe('Release channel'),
+        },
+      })
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(result),
+          },
+        ],
+      }
+    }
+    catch (err) {
+      if (err instanceof McpElicitationError) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: err.code }) }],
+        }
+      }
+      throw err
+    }
+  },
+})

--- a/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/server/mcp/tools/ask-url.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/server/mcp/tools/ask-url.ts
@@ -1,0 +1,30 @@
+import { defineMcpTool } from '../../../../../../src/runtime/server/types'
+import { useMcpElicitation, McpElicitationError } from '../../../../../../src/runtime/server/mcp/elicitation'
+
+export default defineMcpTool({
+  name: 'ask_url',
+  description: 'Open a URL via URL-mode elicitation',
+  inputSchema: {},
+  handler: async () => {
+    const elicit = useMcpElicitation()
+
+    try {
+      const result = await elicit.url({
+        message: 'Open the verification page',
+        url: 'https://example.com/verify',
+      })
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result) }],
+      }
+    }
+    catch (err) {
+      if (err instanceof McpElicitationError) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: err.code }) }],
+        }
+      }
+      throw err
+    }
+  },
+})

--- a/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/server/mcp/tools/supports.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/elicitation/server/mcp/tools/supports.ts
@@ -1,0 +1,22 @@
+import { defineMcpTool } from '../../../../../../src/runtime/server/types'
+import { useMcpElicitation } from '../../../../../../src/runtime/server/mcp/elicitation'
+
+export default defineMcpTool({
+  name: 'supports_check',
+  description: 'Returns which elicitation modes the connected client supports',
+  inputSchema: {},
+  handler: async () => {
+    const elicit = useMcpElicitation()
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            form: elicit.supports('form'),
+            url: elicit.supports('url'),
+          }),
+        },
+      ],
+    }
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@electric-sql/pglite':
         specifier: ^0.4.4
         version: 0.4.4
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@nuxt/ui':
         specifier: ^4.6.1
         version: 4.6.1(699bb06fc4f2c1acd5b0dbb57204db4d)


### PR DESCRIPTION
<img width="832" height="798" alt="CleanShot 2026-04-21 at 11 47 19@2x" src="https://github.com/user-attachments/assets/1f036b83-4b6a-42d6-90ef-779e8edd07c9" />


## Summary

Adds `useMcpElicitation()` — a typed wrapper around the MCP `elicitInput` server method (spec [2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25)) for prompting the connected client during a tool call.

```typescript
const elicit = useMcpElicitation()

const result = await elicit.form({
  message: `Pick a release channel for "${name}"`,
  schema: { channel: z.enum(['stable', 'beta']) },
})
if (result.action !== 'accept') return 'Cancelled.'
```

### What's in the box

- **Form mode** — pass a Zod raw shape; the response is validated and fully typed (Zod → JSON Schema under the hood with the spec's flat-primitive constraint enforced upfront).
- **URL mode** — `elicit.url({ message, url })` redirects the user to a hosted page (opt-in per the spec).
- **Confirm helper** — `elicit.confirm(message)` returns a `boolean`.
- **Capability detection** — `elicit.supports('form' | 'url')` follows the spec's backward-compat rule: empty `elicitation: {}` defaults to form support; explicit `url` requires explicit `form`.
- **Typed errors** — `McpElicitationError` with `code: 'unsupported' | 'invalid-schema' | 'invalid-response'` so callers can fall back gracefully.
- **Re-exports** — `useMcpServer()` and `useMcpSession()` are now also re-exported from `@nuxtjs/mcp-toolkit/server`.

### Side effect: DevTools Inspector launch fix

Bumps the MCP Inspector cold-start timeout to 60s and adds a fast-path that resolves as soon as the inspector emits its ready URL with the captured `MCP_PROXY_AUTH_TOKEN`. Without this fix the iframe sometimes embeds before the auth token is available and renders broken — this surfaced repeatedly while testing elicitation against the Inspector.

### Playground

New `/mcp-test` console with two demo tools (`release_channel`, `connect_account`) and an interactive elicitation modal that handles form & URL modes plus accept/decline/cancel.

### Docs

- New page `advanced/elicitation` covering the full API surface and capability-handshake matrix.
- New "Interactive Composables" section in the manage-mcp skill.