### PR TITLE
feat(module): add `useMcpLogger` + evlog integration

### DIFF
--- a/.changeset/use-mcp-logger.md
+++ b/.changeset/use-mcp-logger.md
@@ -1,0 +1,42 @@
+---
+"@nuxtjs/mcp-toolkit": minor
+---
+
+Add `useMcpLogger()` and first-class observability via [evlog](https://evlog.dev), shipped as a direct dependency.
+
+The composable is split into two clearly-named channels so it's always obvious what reaches the user vs. your server logs:
+
+```typescript
+const log = useMcpLogger('billing')
+
+// → MCP client (Inspector / Cursor / Claude — notifications/message)
+await log.notify.info({ msg: 'starting charge', amount })
+
+// → server-side wide event (dev terminal + drains)
+log.set({ user: { id: userId } })
+log.event('charge_started', { amount })
+```
+
+- **Client channel** — `log.notify(level, data, logger?)` plus `notify.debug` / `notify.info` / `notify.warning` / `notify.error` shortcuts. Always resolves, never throws, and respects the client's `logging/setLevel` per session. The toolkit declares the `logging` server capability automatically.
+- **Server channel** — `log.set(fields)` accumulates context onto the request's evlog wide event; `log.event(name, fields?)` captures a discrete event; `log.evlog` exposes the full [`RequestLogger`](https://evlog.dev/docs/api/request-logger) (`fork`, `error`, `getContext`, …).
+
+### Native MCP wide-event tagging
+
+Every MCP request is wrapped in an evlog wide event natively tagged with the JSON-RPC payload — no user code required:
+
+| Field | Description |
+|---|---|
+| `mcp.transport` | `streamable-http` / `cloudflare-do` |
+| `mcp.route` | The configured MCP endpoint path |
+| `mcp.session_id` | From the `mcp-session-id` header |
+| `mcp.method` | `tools/call`, `tools/list`, `initialize`, … |
+| `mcp.request_id` | The JSON-RPC id |
+| `mcp.tool` / `mcp.resource` / `mcp.prompt` | Filled per `tools/call` / `resources/read` / `prompts/get` |
+
+Batched JSON-RPC payloads expose plural arrays (`mcp.methods`, `mcp.tools`, …).
+
+### evlog integration
+
+`evlog` is now a direct dependency. The Nitro module is wired automatically. Configure drains (Axiom, OTLP, HyperDX, Sentry, Datadog, …), sampling, and redaction via `mcp.logging` in `nuxt.config.ts`, or set `mcp.logging: false` to opt out entirely (the `notify` channel keeps working).
+
+The integration plays nicely with `@nuxthub/core` and other modules that pull in CLI dependencies (e.g. `drizzle-kit`) — we no longer force `noExternals: true` globally; instead we inline only `evlog` and `evlog/nitro`.

--- a/.changeset/use-mcp-logger.md
+++ b/.changeset/use-mcp-logger.md
@@ -2,27 +2,43 @@
 "@nuxtjs/mcp-toolkit": minor
 ---
 
-Add `useMcpLogger()` and first-class observability via [evlog](https://evlog.dev), shipped as a direct dependency.
+Add `useMcpLogger()` and first-class observability via [evlog](https://evlog.dev), shipped as an **optional peer dependency**.
 
 The composable is split into two clearly-named channels so it's always obvious what reaches the user vs. your server logs:
 
 ```typescript
 const log = useMcpLogger('billing')
 
-// → MCP client (Inspector / Cursor / Claude — notifications/message)
+// → MCP client (Inspector / Cursor / Claude — notifications/message). Always works.
 await log.notify.info({ msg: 'starting charge', amount })
 
-// → server-side wide event (dev terminal + drains)
+// → server-side wide event (dev terminal + drains). Requires `evlog` installed.
 log.set({ user: { id: userId } })
 log.event('charge_started', { amount })
 ```
 
-- **Client channel** — `log.notify(level, data, logger?)` plus `notify.debug` / `notify.info` / `notify.warning` / `notify.error` shortcuts. Always resolves, never throws, and respects the client's `logging/setLevel` per session. The toolkit declares the `logging` server capability automatically.
-- **Server channel** — `log.set(fields)` accumulates context onto the request's evlog wide event; `log.event(name, fields?)` captures a discrete event; `log.evlog` exposes the full [`RequestLogger`](https://evlog.dev/docs/api/request-logger) (`fork`, `error`, `getContext`, …).
+- **Client channel** — `log.notify(level, data, logger?)` plus `notify.debug` / `notify.info` / `notify.warning` / `notify.error` shortcuts. Always resolves, never throws, and respects the client's `logging/setLevel` per session. The toolkit declares the `logging` server capability automatically. Works without `evlog`.
+- **Server channel** — `log.set(fields)` accumulates context onto the request's evlog wide event; `log.event(name, fields?)` captures a discrete event; `log.evlog` exposes the full [`RequestLogger`](https://evlog.dev/docs/api/request-logger) (`fork`, `error`, `getContext`, …). Throws `McpObservabilityNotEnabledError` when observability is off.
+
+### Opt-in observability
+
+`evlog` is an **optional peer dependency** — install it to unlock wide events:
+
+```bash
+pnpm add evlog
+```
+
+`mcp.logging` modes:
+
+| Value | Behavior |
+|---|---|
+| omitted (default) | Auto-detect: on if `evlog` is installed, off otherwise. |
+| `true` or object | Force on. Build throws with install instructions if `evlog` is missing. |
+| `false` | Force off. `notify` keeps working; `set` / `event` / `evlog` throw `McpObservabilityNotEnabledError`. |
 
 ### Native MCP wide-event tagging
 
-Every MCP request is wrapped in an evlog wide event natively tagged with the JSON-RPC payload — no user code required:
+When observability is active, every MCP request is wrapped in an evlog wide event natively tagged with the JSON-RPC payload — no user code required:
 
 | Field | Description |
 |---|---|
@@ -35,8 +51,21 @@ Every MCP request is wrapped in an evlog wide event natively tagged with the JSO
 
 Batched JSON-RPC payloads expose plural arrays (`mcp.methods`, `mcp.tools`, …).
 
-### evlog integration
+### Ship to your observability stack
 
-`evlog` is now a direct dependency. The Nitro module is wired automatically. Configure drains (Axiom, OTLP, HyperDX, Sentry, Datadog, …), sampling, and redaction via `mcp.logging` in `nuxt.config.ts`, or set `mcp.logging: false` to opt out entirely (the `notify` channel keeps working).
+Once `evlog` is installed, every MCP wide event can be forwarded to **Axiom, Sentry, OTLP, HyperDX, Datadog, Better Stack, or PostHog** with a single Nitro plugin — no MCP-specific glue, just the standard `evlog:drain` hook:
 
-The integration plays nicely with `@nuxthub/core` and other modules that pull in CLI dependencies (e.g. `drizzle-kit`) — we no longer force `noExternals: true` globally; instead we inline only `evlog` and `evlog/nitro`.
+```typescript
+// server/plugins/evlog-axiom.ts
+import { createAxiomDrain } from 'evlog/adapters/axiom'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('evlog:drain', createAxiomDrain())
+})
+```
+
+Register multiple drains in parallel, or write a custom one with `(ctx) => Promise<void>`. See [evlog.dev](https://evlog.dev) for the full list.
+
+### Compatibility
+
+When wired in, the integration plays nicely with `@nuxthub/core` and other modules that pull in CLI dependencies (e.g. `drizzle-kit`) — we no longer force `noExternals: true` globally; instead we inline only `evlog` and `evlog/nitro`.

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 node_modules
 
 # Logs
-*.log*
+*.log
+*.log.*
 
 # Temp directories
 .temp

--- a/apps/docs/content/3.advanced/10.logging.md
+++ b/apps/docs/content/3.advanced/10.logging.md
@@ -30,8 +30,10 @@ Add structured logging to my Nuxt MCP server (@nuxtjs/mcp-toolkit).
 - log.set({ user: { id } }) accumulates context onto the request's evlog wide event
 - log.event('charge_started', { amount }) captures a discrete event in the same wide event
 - log.evlog gives you the underlying RequestLogger (fork, error, getContext, …)
-- Configure drains, sampling, and redaction via mcp.logging in nuxt.config.ts
-- Disable evlog entirely with mcp.logging: false (notify still works)
+- Install the optional evlog peer dep to enable wide events: `pnpm add evlog`
+- Ship to Axiom / Sentry / Datadog / OTLP / HyperDX / Better Stack / PostHog with one Nitro plugin (`server/plugins/evlog-axiom.ts`)
+- Custom drains: register any `(ctx) => Promise<void>` on the `evlog:drain` hook
+- Disable observability entirely with mcp.logging: false (notify still works)
 
 Docs: https://mcp-toolkit.nuxt.dev/advanced/logging
 ```
@@ -40,29 +42,40 @@ Docs: https://mcp-toolkit.nuxt.dev/advanced/logging
 
 ## Setup
 
-The toolkit ships [evlog](https://evlog.dev) as a direct dependency and registers its Nitro module automatically. There's nothing to install — wide events show up in your dev terminal out of the box.
+`log.notify(...)` works out of the box — no extra setup needed. Server-side wide events are powered by the optional [evlog](https://evlog.dev) peer dependency.
+
+### Enable wide events
+
+Install evlog alongside the toolkit:
+
+```bash
+pnpm add evlog
+```
+
+That's it. The toolkit auto-detects evlog and wires it into Nitro automatically — wide events show up in your dev terminal on every MCP request, with `mcp.tool`, `mcp.session_id`, and friends already tagged.
+
+### Configure (optional)
+
+Forward [evlog Nitro options](https://evlog.dev) under `mcp.logging`:
 
 ```typescript [nuxt.config.ts]
 export default defineNuxtConfig({
   modules: ['@nuxtjs/mcp-toolkit'],
   mcp: {
-    // Optional — defaults shown
     logging: {
-      // Forward any evlog/nitro options here (see https://evlog.dev)
+      // Forward any evlog/nitro options here (drains, sampling, redaction, …)
     },
   },
 })
 ```
 
-Pass `false` to opt out of the evlog wiring entirely (the `notify` channel still works, but `set` / `event` become no-ops):
+### Force on / opt out
 
-```typescript [nuxt.config.ts]
-export default defineNuxtConfig({
-  mcp: {
-    logging: false,
-  },
-})
-```
+| `mcp.logging` value | Behavior |
+|---|---|
+| `undefined` (default) | Auto-detect: on if `evlog` is installed, off otherwise. |
+| `true` or object | Force on. Build throws with install instructions if `evlog` is missing. |
+| `false` | Force off. `log.notify(...)` keeps working; `log.set(...)` / `log.event(...)` / `log.evlog` throw an `McpObservabilityNotEnabledError`. |
 
 ## `useMcpLogger()`
 
@@ -183,7 +196,44 @@ INFO [Playground MCP] POST /mcp 200 in 18ms
 └─ requestLogs: 0={"level":"info","message":"rows_fetched",...}
 ```
 
-Configure drains (Axiom, OTLP, HyperDX, Sentry, …), sampling, and PII redaction via the standard evlog Nitro options under `mcp.logging`. See the [evlog docs](https://evlog.dev/docs) for the full list.
+## Ship to Your Observability Stack
+
+evlog ships **drain adapters** for Axiom, Sentry, OpenTelemetry / OTLP, HyperDX, Datadog, Better Stack, and PostHog. A drain is just a function registered on the `evlog:drain` Nitro hook — every MCP wide event (already tagged with `mcp.tool`, `mcp.session_id`, …) is forwarded to whichever destinations you wire up.
+
+The pattern is always the same: drop a Nitro plugin under `server/plugins/` that imports a `createXxxDrain()` from `evlog/adapters/*` and registers it on the hook. Most adapters are **zero-config** if you set the standard env vars.
+
+```typescript [server/plugins/evlog-axiom.ts]
+import { createAxiomDrain } from 'evlog/adapters/axiom'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('evlog:drain', createAxiomDrain())
+})
+```
+
+```bash [.env]
+NUXT_AXIOM_TOKEN=xaat-...
+NUXT_AXIOM_DATASET=mcp-server
+```
+
+You can now slice MCP traffic in Axiom by `mcp.tool`, `mcp.session_id`, `user.id`, latency, error rate — every field you `set()` on a wide event is queryable.
+
+The hook is additive: register multiple drains for parallel forwarding (e.g. Axiom for storage + Sentry for alerting), and a failure in one drain doesn't affect the others.
+
+```typescript [server/plugins/evlog-drains.ts]
+import { createAxiomDrain } from 'evlog/adapters/axiom'
+import { createSentryDrain } from 'evlog/adapters/sentry'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('evlog:drain', createAxiomDrain())
+  nitroApp.hooks.hook('evlog:drain', createSentryDrain())
+})
+```
+
+A drain is just `(ctx: DrainContext | DrainContext[]) => Promise<void>` — write your own for Slack alerts on failed `tools/call`, persisting to your own database for audit, forwarding to an internal SIEM, etc.
+
+::callout{icon="i-lucide-arrow-up-right" to="https://evlog.dev" target="_blank"}
+See the [evlog docs](https://evlog.dev) for the full list of adapters, configuration options (sampling, redaction, enrichers), and how to build custom drains.
+::
 
 ## Production Tips
 
@@ -194,5 +244,5 @@ Configure drains (Axiom, OTLP, HyperDX, Sentry, …), sampling, and PII redactio
 ## Requirements
 
 ::callout{icon="i-lucide-triangle-alert" color="warning"}
-`useMcpLogger()` requires `nitro.experimental.asyncContext` to be `true` (default since Nuxt 3.8+). The `set`, `event`, and `evlog` channels are no-ops when `mcp.logging` is set to `false`.
+`useMcpLogger()` requires `nitro.experimental.asyncContext` to be `true` (default since Nuxt 3.8+). The `set`, `event`, and `evlog` channels throw an `McpObservabilityNotEnabledError` when the optional `evlog` peer dependency is missing or `mcp.logging` is set to `false`. The `notify` channel keeps working in both cases.
 ::

--- a/apps/docs/content/3.advanced/10.logging.md
+++ b/apps/docs/content/3.advanced/10.logging.md
@@ -1,0 +1,198 @@
+---
+title: Logging
+description: Stream logs to MCP clients and capture structured wide events with useMcpLogger().
+navigation:
+  icon: i-lucide-scroll-text
+seo:
+  title: MCP Logging & Observability
+  description: Send notifications/message to connected MCP clients and capture structured server-side wide events with the built-in evlog integration.
+---
+
+## Two Channels, One Composable
+
+`useMcpLogger()` exposes a **split-channel** API because the two destinations have very different audiences:
+
+| Channel | Audience | API |
+|---------|----------|-----|
+| **Client notifications** (`notifications/message`) | The end user / agent UI (Cursor, Claude, MCP Inspector, …) | `log.notify(...)`, `log.notify.debug/info/warning/error(...)` |
+| **Wide events** (server-side, powered by [evlog](https://evlog.dev)) | Operators, dev terminal, drains (Axiom, OTLP, Datadog, …) | `log.set(...)`, `log.event(...)`, `log.evlog` |
+
+Notifications are **user-facing** and may end up in chat transcripts. Wide events are **operator-facing**, pretty-printed in the dev terminal at the end of each request and shipped to drains in production.
+
+::code-collapse
+
+```txt [Prompt]
+Add structured logging to my Nuxt MCP server (@nuxtjs/mcp-toolkit).
+
+- Use useMcpLogger() inside a tool handler (auto-imported)
+- log.notify.info({ … }) sends notifications/message to the connected MCP client
+- Shortcuts: log.notify.debug/info/warning/error — respect logging/setLevel
+- log.set({ user: { id } }) accumulates context onto the request's evlog wide event
+- log.event('charge_started', { amount }) captures a discrete event in the same wide event
+- log.evlog gives you the underlying RequestLogger (fork, error, getContext, …)
+- Configure drains, sampling, and redaction via mcp.logging in nuxt.config.ts
+- Disable evlog entirely with mcp.logging: false (notify still works)
+
+Docs: https://mcp-toolkit.nuxt.dev/advanced/logging
+```
+
+::
+
+## Setup
+
+The toolkit ships [evlog](https://evlog.dev) as a direct dependency and registers its Nitro module automatically. There's nothing to install — wide events show up in your dev terminal out of the box.
+
+```typescript [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/mcp-toolkit'],
+  mcp: {
+    // Optional — defaults shown
+    logging: {
+      // Forward any evlog/nitro options here (see https://evlog.dev)
+    },
+  },
+})
+```
+
+Pass `false` to opt out of the evlog wiring entirely (the `notify` channel still works, but `set` / `event` become no-ops):
+
+```typescript [nuxt.config.ts]
+export default defineNuxtConfig({
+  mcp: {
+    logging: false,
+  },
+})
+```
+
+## `useMcpLogger()`
+
+Auto-imported. Must be called inside a tool, resource, or prompt handler.
+
+```typescript [server/mcp/tools/charge.ts]
+import { z } from 'zod'
+import { defineMcpTool } from '@nuxtjs/mcp-toolkit/server'
+
+export default defineMcpTool({
+  name: 'charge_card',
+  description: 'Charge a payment method',
+  inputSchema: {
+    userId: z.string(),
+    amount: z.number().int(),
+  },
+  handler: async ({ userId, amount }) => {
+    const log = useMcpLogger('billing')
+
+    // → server: merged into the request's wide event, printed in the
+    //   dev terminal at the end of the request, shipped to drains.
+    log.set({ user: { id: userId }, billing: { amount } })
+
+    // → client: appears in the MCP Inspector "Server Notifications" panel
+    //   (and in Cursor / Claude's log viewer). Honours `logging/setLevel`.
+    await log.notify.info({ msg: 'starting charge', amount })
+
+    try {
+      const receipt = await charge(userId, amount)
+      log.event('charge_completed', { receiptId: receipt.id })
+      await log.notify.info({ msg: 'charge ok', receiptId: receipt.id })
+      return `Charged ${amount}.`
+    }
+    catch (err) {
+      log.evlog.error('charge failed', err)
+      await log.notify.error({ msg: 'charge failed', error: String(err) })
+      throw err
+    }
+  },
+})
+```
+
+What happens:
+
+1. The MCP client receives **two `notifications/message`** entries (`info`, `info`) and one `error` if the charge fails.
+2. The wide event for this request is enriched with `user.id`, `billing.amount`, plus a `charge_completed` (or `charge_failed`) discrete event — visible in your dev terminal and forwarded to any configured evlog drain.
+
+### API
+
+| Method | Channel | Description |
+|--------|---------|-------------|
+| `notify(level, data, logger?)` | client | Send a `notifications/message`. Drops silently when the level is filtered out by the client. |
+| `notify.debug(data, logger?)` | client | Shortcut for `notify('debug', …)`. |
+| `notify.info(data, logger?)` | client | Shortcut for `notify('info', …)`. |
+| `notify.warning(data, logger?)` | client | Shortcut for `notify('warning', …)`. |
+| `notify.error(data, logger?)` | client | Shortcut for `notify('error', …)`. |
+| `set(fields)` | server (evlog) | Merge fields into the current request's wide event. |
+| `event(name, fields?)` | server (evlog) | Capture a discrete event in the wide event's request log. |
+| `evlog` | server (evlog) | Underlying [`RequestLogger`](https://evlog.dev/docs/api/request-logger) — `fork`, `error`, `getContext`, `emit`, … |
+
+`logger` is the prefix attached to the notification (visible to the client). Pass it as the argument to `useMcpLogger('prefix')` to set a default for the request, or pass it per call to override.
+
+### Level Filtering
+
+Per the MCP spec, clients can call `logging/setLevel` to filter which messages they want. The toolkit forwards the current MCP session id to the SDK so each session's filter is applied independently — `log.notify.debug(...)` becomes a no-op for clients that asked for `warning` or higher.
+
+The `notify` methods always resolve and never throw, even when the transport is disconnected or the level is filtered out, so you can use them freely on hot paths.
+
+## Wide Events with evlog
+
+Every MCP request is wrapped in an evlog **wide event** — one structured log line per request, accumulated as the handler runs. The toolkit automatically tags each wide event with:
+
+| Field | Description |
+|-------|-------------|
+| `mcp.transport` | `streamable-http` (default) or `cloudflare-do` on Workers |
+| `mcp.route` | The configured MCP endpoint path |
+| `mcp.session_id` | Copied from the `mcp-session-id` header (when present) |
+| `mcp.method` | The JSON-RPC method (`tools/call`, `tools/list`, `initialize`, `resources/read`, `prompts/get`, `notifications/initialized`, …) |
+| `mcp.request_id` | The JSON-RPC request id when the message has one |
+| `mcp.tool` | The tool name on a `tools/call` request |
+| `mcp.resource` | The URI on a `resources/read` request |
+| `mcp.prompt` | The prompt name on a `prompts/get` request |
+
+For batched JSON-RPC payloads the singular keys (`method`, `tool`, `resource`, `prompt`, `request_id`) flip to plural arrays (`methods`, `tools`, `resources`, `prompts`, `request_ids`). No user code or middleware is required — these fields land on every request automatically.
+
+You stack additional context with `set()` and capture milestones with `event()`:
+
+```typescript [server/mcp/tools/import-csv.ts]
+import { defineMcpTool } from '@nuxtjs/mcp-toolkit/server'
+
+export default defineMcpTool({
+  name: 'import_csv',
+  description: 'Import a CSV file',
+  inputSchema: { url: z.string().url() },
+  handler: async ({ url }) => {
+    const log = useMcpLogger('import')
+    log.set({ source: { kind: 'csv', url } })
+
+    const rows = await fetchCsv(url)
+    log.event('rows_fetched', { count: rows.length })
+
+    const inserted = await insertRows(rows)
+    log.set({ result: { inserted } })
+
+    return `Imported ${inserted} rows.`
+  },
+})
+```
+
+In your dev terminal you'll get something like:
+
+```bash
+INFO [Playground MCP] POST /mcp 200 in 18ms
+├─ requestId: c6a9094f-bd24-4971-88ee-a53a28fab13a
+├─ mcp: transport=streamable-http route=/mcp session_id=ef39698f-… method=tools/call request_id=1 tool=import_csv
+├─ source: kind=csv url=https://example.com/data.csv
+├─ result: inserted=128
+└─ requestLogs: 0={"level":"info","message":"rows_fetched",...}
+```
+
+Configure drains (Axiom, OTLP, HyperDX, Sentry, …), sampling, and PII redaction via the standard evlog Nitro options under `mcp.logging`. See the [evlog docs](https://evlog.dev/docs) for the full list.
+
+## Production Tips
+
+- **Use `notify` sparingly.** Each notification is a network round-trip and ends up in the user's chat history. Keep it for actionable progress updates ("opened PR #42") or genuine errors.
+- **Use `set` and `event` liberally.** They're cheap, batched into the wide event, and never leak to the client. This is where you put structured business data, timings, retry counts, etc.
+- **Pair with `extractToolNames()`.** Combine `useMcpLogger()` in middleware with [`extractToolNames(event)`](/advanced/middleware) to record every tool call, including failed ones, for audit trails.
+
+## Requirements
+
+::callout{icon="i-lucide-triangle-alert" color="warning"}
+`useMcpLogger()` requires `nitro.experimental.asyncContext` to be `true` (default since Nuxt 3.8+). The `set`, `event`, and `evlog` channels are no-ops when `mcp.logging` is set to `false`.
+::

--- a/apps/docs/skills/manage-mcp/SKILL.md
+++ b/apps/docs/skills/manage-mcp/SKILL.md
@@ -389,6 +389,41 @@ See [elicitation docs →](https://mcp-toolkit.nuxt.dev/advanced/elicitation)
 
 ---
 
+## Observability
+
+### `useMcpLogger()`
+
+Split-channel logger: notify the connected client and capture structured wide events (powered by [evlog](https://evlog.dev), shipped as a direct dependency).
+
+```typescript
+export default defineMcpTool({
+  name: 'charge_card',
+  inputSchema: { userId: z.string(), amount: z.number().int() },
+  handler: async ({ userId, amount }) => {
+    const log = useMcpLogger('billing')
+
+    // → server-side wide event (dev terminal + drains)
+    log.set({ user: { id: userId }, billing: { amount } })
+    log.event('charge_started', { amount })
+
+    // → MCP client (Inspector / Cursor / Claude)
+    await log.notify.info({ msg: 'starting charge', amount })
+
+    const receipt = await charge(userId, amount)
+    return `Charged ${amount}.`
+  },
+})
+```
+
+- **Client channel** (`log.notify`): `notify(level, data, logger?)` plus `notify.debug` / `notify.info` / `notify.warning` / `notify.error` shortcuts. Always resolves, never throws — respects the client's `logging/setLevel` per session.
+- **Server channel**: `set(fields)` accumulates context onto the request's evlog wide event; `event(name, fields?)` captures a discrete event; `evlog` exposes the full `RequestLogger`.
+- Wide events are auto-tagged with `mcp.transport`, `mcp.route`, `mcp.session_id`, `mcp.method`, `mcp.request_id`, and `mcp.tool` / `mcp.resource` / `mcp.prompt` based on the JSON-RPC payload (no user code required).
+- Configure drains, sampling, redaction via `mcp.logging` in `nuxt.config.ts`. Pass `logging: false` to disable evlog entirely (the `notify` channel keeps working).
+
+See [logging docs →](https://mcp-toolkit.nuxt.dev/advanced/logging)
+
+---
+
 ## Review & Best Practices
 
 ### MCP code review (agents & humans)

--- a/apps/docs/skills/manage-mcp/SKILL.md
+++ b/apps/docs/skills/manage-mcp/SKILL.md
@@ -393,7 +393,7 @@ See [elicitation docs →](https://mcp-toolkit.nuxt.dev/advanced/elicitation)
 
 ### `useMcpLogger()`
 
-Split-channel logger: notify the connected client and capture structured wide events (powered by [evlog](https://evlog.dev), shipped as a direct dependency).
+Split-channel logger: notify the connected client and capture structured wide events (powered by [evlog](https://evlog.dev), an **optional peer dependency** — install with `pnpm add evlog` to enable wide events).
 
 ```typescript
 export default defineMcpTool({
@@ -415,10 +415,26 @@ export default defineMcpTool({
 })
 ```
 
-- **Client channel** (`log.notify`): `notify(level, data, logger?)` plus `notify.debug` / `notify.info` / `notify.warning` / `notify.error` shortcuts. Always resolves, never throws — respects the client's `logging/setLevel` per session.
-- **Server channel**: `set(fields)` accumulates context onto the request's evlog wide event; `event(name, fields?)` captures a discrete event; `evlog` exposes the full `RequestLogger`.
+- **Client channel** (`log.notify`): `notify(level, data, logger?)` plus `notify.debug` / `notify.info` / `notify.warning` / `notify.error` shortcuts. Always resolves, never throws — respects the client's `logging/setLevel` per session. Works with or without `evlog`.
+- **Server channel** (requires `evlog` installed): `set(fields)` accumulates context onto the request's wide event; `event(name, fields?)` captures a discrete event; `evlog` exposes the full request logger. These throw `McpObservabilityNotEnabledError` when observability is off.
 - Wide events are auto-tagged with `mcp.transport`, `mcp.route`, `mcp.session_id`, `mcp.method`, `mcp.request_id`, and `mcp.tool` / `mcp.resource` / `mcp.prompt` based on the JSON-RPC payload (no user code required).
-- Configure drains, sampling, redaction via `mcp.logging` in `nuxt.config.ts`. Pass `logging: false` to disable evlog entirely (the `notify` channel keeps working).
+- `mcp.logging` modes: omit (auto-detect — on if `evlog` installed), `true` / object (force on, throws at build if missing), `false` (force off — `notify` keeps working).
+
+#### Ship to a backend (drains)
+
+Ship every MCP wide event to **Axiom, Sentry, OTLP, HyperDX, Datadog, Better Stack, or PostHog** with a single Nitro plugin. Each adapter lives under `evlog/adapters/*` and is registered on the `evlog:drain` hook:
+
+```typescript [server/plugins/evlog-axiom.ts]
+import { createAxiomDrain } from 'evlog/adapters/axiom'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('evlog:drain', createAxiomDrain())
+})
+```
+
+The hook is additive — register multiple drains in parallel. Custom drains are just `(ctx) => Promise<void>` registered on the same hook.
+
+See [evlog.dev →](https://evlog.dev) for the full list of adapters, env-var conventions, sampling, and redaction.
 
 See [logging docs →](https://mcp-toolkit.nuxt.dev/advanced/logging)
 

--- a/apps/docs/skills/manage-mcp/references/tools.md
+++ b/apps/docs/skills/manage-mcp/references/tools.md
@@ -118,6 +118,77 @@ export default defineMcpTool({
 })
 ```
 
+## Interactive Tool (Elicitation)
+
+Ask the user for missing details mid-request and validate the response against a Zod shape.
+
+```typescript
+import { z } from 'zod'
+
+export default defineMcpTool({
+  description: 'Create a release after asking for the channel',
+  inputSchema: {
+    name: z.string().describe('Release name'),
+  },
+  handler: async ({ name }) => {
+    const elicit = useMcpElicitation()
+
+    if (!elicit.supports('form')) {
+      return `Use a client that supports elicitation, then re-run for "${name}".`
+    }
+
+    const result = await elicit.form({
+      message: `Pick a release channel for "${name}"`,
+      schema: {
+        channel: z.enum(['stable', 'beta', 'canary']).describe('Release channel'),
+        notify: z.boolean().default(true).describe('Notify subscribers'),
+      },
+    })
+
+    if (result.action !== 'accept') {
+      return `Release cancelled (${result.action}).`
+    }
+
+    return `Created "${name}" on ${result.content.channel} (notify=${result.content.notify}).`
+  },
+})
+```
+
+## Observability (Logger)
+
+Stream `notifications/message` to the client and capture a structured wide event for each request.
+
+```typescript
+import { z } from 'zod'
+
+export default defineMcpTool({
+  description: 'Charge a payment method',
+  inputSchema: {
+    userId: z.string(),
+    amount: z.number().int().positive(),
+  },
+  annotations: { destructiveHint: true, idempotentHint: false },
+  handler: async ({ userId, amount }) => {
+    const log = useMcpLogger('billing')
+
+    log.set({ user: { id: userId }, billing: { amount } })
+    await log.notify.info({ msg: 'starting charge', amount })
+
+    try {
+      const receipt = await chargeCard(userId, amount)
+      log.event('charge_completed', { receiptId: receipt.id })
+      await log.notify.info({ msg: 'charge ok', receiptId: receipt.id })
+      return `Charged ${amount}. Receipt: ${receipt.id}`
+    }
+    catch (err) {
+      log.evlog.error('charge failed', err)
+      await log.notify.error({ msg: 'charge failed', error: String(err) })
+      throw err
+    }
+  },
+})
+```
+
 ## File Operation
 
 ```typescript

--- a/apps/playground/app/composables/mcp-tester.ts
+++ b/apps/playground/app/composables/mcp-tester.ts
@@ -1,6 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { ElicitRequestSchema, LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
 
 export type ElicitionMode = 'form' | 'url'
 
@@ -14,6 +14,14 @@ export interface PendingElicit {
     required?: string[]
   }
   resolve: (response: { action: 'accept' | 'decline' | 'cancel', content?: Record<string, unknown> }) => void
+}
+
+export interface NotificationEntry {
+  id: string
+  level: string
+  data: unknown
+  logger?: string
+  receivedAt: number
 }
 
 export interface ToolCallEntry {
@@ -44,6 +52,7 @@ export function useMcpTester() {
   const sessionId = ref<string | null>(null)
   const tools = ref<ToolDescriptor[]>([])
   const toolCalls = ref<ToolCallEntry[]>([])
+  const notifications = ref<NotificationEntry[]>([])
   const pendingElicit = ref<PendingElicit | null>(null)
   const options = ref<ConnectOptions>({ ...DEFAULT_OPTIONS })
 
@@ -52,6 +61,7 @@ export function useMcpTester() {
 
   function reset() {
     toolCalls.value = []
+    notifications.value = []
     tools.value = []
     sessionId.value = null
     pendingElicit.value = null
@@ -114,6 +124,17 @@ export function useMcpTester() {
         })
       }
 
+      client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+        const params = notification.params as { level: string, data: unknown, logger?: string }
+        notifications.value.unshift({
+          id: crypto.randomUUID(),
+          level: params.level,
+          data: params.data,
+          logger: params.logger,
+          receivedAt: Date.now(),
+        })
+      })
+
       transport = new StreamableHTTPClientTransport(new URL('/mcp', window.location.origin))
       await client.connect(transport)
       sessionId.value = transport.sessionId ?? null
@@ -159,6 +180,15 @@ export function useMcpTester() {
     pendingElicit.value?.resolve(response)
   }
 
+  async function setLevel(level: 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency') {
+    if (!client) throw new Error('Not connected')
+    await client.setLoggingLevel(level)
+  }
+
+  function clearNotifications() {
+    notifications.value = []
+  }
+
   function clearCalls() {
     toolCalls.value = []
   }
@@ -169,12 +199,15 @@ export function useMcpTester() {
     sessionId,
     tools,
     toolCalls,
+    notifications,
     pendingElicit,
     options,
     connect,
     disconnect,
     callTool,
     answerElicit,
+    setLevel,
+    clearNotifications,
     clearCalls,
   }
 }

--- a/apps/playground/app/pages/mcp-test.vue
+++ b/apps/playground/app/pages/mcp-test.vue
@@ -5,14 +5,15 @@ definePageMeta({
 
 useSeoMeta({
   title: 'MCP Test Console',
-  description: 'Interactively test elicitation features against the playground MCP server.',
+  description: 'Interactively test elicitation, logging notifications and wide events against the playground MCP server.',
 })
 
 const tester = useMcpTester()
 const formAnswers = ref<Record<string, unknown>>({})
 const toolArgs = ref<Record<string, Record<string, unknown>>>({})
+const currentLevel = ref<'debug' | 'info' | 'warning' | 'error'>('debug')
 
-const featuredToolNames = ['release_channel', 'connect_account']
+const featuredToolNames = ['release_channel', 'connect_account', 'observability_demo']
 
 const featuredTools = computed(() => {
   return featuredToolNames
@@ -28,6 +29,13 @@ const elicitationOptions = [
   { label: 'Form mode (default)', value: 'form' },
   { label: 'Form + URL mode', value: 'form+url' },
   { label: 'Disabled (refuse all)', value: 'none' },
+] as const
+
+const levels = [
+  { label: 'debug (verbose)', value: 'debug' },
+  { label: 'info', value: 'info' },
+  { label: 'warning', value: 'warning' },
+  { label: 'error (silent unless error)', value: 'error' },
 ] as const
 
 const statusColor = computed(() => {
@@ -83,6 +91,10 @@ async function runTool(toolName: string) {
   await tester.callTool(toolName, args)
 }
 
+async function applyLevel() {
+  await tester.setLevel(currentLevel.value)
+}
+
 watch(() => tester.pendingElicit.value, (next) => {
   if (next?.mode === 'form' && next.requestedSchema) {
     const initial: Record<string, unknown> = {}
@@ -108,6 +120,13 @@ function formatResult(entry: typeof tester.toolCalls.value[number]) {
 
 function formatTime(ts: number) {
   return new Date(ts).toLocaleTimeString()
+}
+
+function levelColor(level: string): 'neutral' | 'info' | 'warning' | 'error' {
+  if (level === 'debug') return 'neutral'
+  if (level === 'info' || level === 'notice') return 'info'
+  if (level === 'warning') return 'warning'
+  return 'error'
 }
 
 onMounted(() => {
@@ -189,17 +208,40 @@ onBeforeUnmount(() => {
             </div>
           </template>
 
-          <UFormField
-            label="Elicitation capability"
-            hint="Switch to test how tools react when the client supports different modes."
-          >
-            <USelect
-              :model-value="tester.options.value.elicitation"
-              :items="[...elicitationOptions]"
-              class="w-full sm:max-w-sm"
-              @update:model-value="(value: string) => tester.connect({ elicitation: value as 'none' | 'form' | 'form+url' })"
-            />
-          </UFormField>
+          <div class="grid gap-4 md:grid-cols-2">
+            <UFormField
+              label="Elicitation capability"
+              hint="Switch to test how tools react when the client supports different modes."
+            >
+              <USelect
+                :model-value="tester.options.value.elicitation"
+                :items="[...elicitationOptions]"
+                class="w-full"
+                @update:model-value="(value: string) => tester.connect({ elicitation: value as 'none' | 'form' | 'form+url' })"
+              />
+            </UFormField>
+
+            <UFormField
+              label="Client log level (logging/setLevel)"
+              hint="Filter which notifications/message entries the server forwards."
+            >
+              <div class="flex gap-2">
+                <USelect
+                  v-model="currentLevel"
+                  :items="[...levels]"
+                  class="flex-1"
+                />
+                <UButton
+                  color="neutral"
+                  variant="subtle"
+                  :disabled="tester.status.value !== 'connected'"
+                  @click="applyLevel"
+                >
+                  Apply
+                </UButton>
+              </div>
+            </UFormField>
+          </div>
         </UCard>
 
         <UCard>
@@ -271,63 +313,114 @@ onBeforeUnmount(() => {
           </div>
         </UCard>
 
-        <UCard>
-          <template #header>
-            <div class="flex items-center justify-between">
-              <h2 class="font-semibold">
-                Tool calls
-              </h2>
-              <UButton
-                size="xs"
-                color="neutral"
-                variant="ghost"
-                icon="i-lucide-trash-2"
-                @click="tester.clearCalls()"
-              >
-                Clear
-              </UButton>
-            </div>
-          </template>
-          <div
-            v-if="tester.toolCalls.value.length === 0"
-            class="py-8 text-center text-sm text-muted"
-          >
-            No calls yet. Pick a tool above and hit Run.
-          </div>
-          <ul class="space-y-3">
-            <li
-              v-for="entry in tester.toolCalls.value"
-              :key="entry.id"
-              class="rounded-md border border-default bg-elevated/40 p-3"
+        <div class="grid gap-6 lg:grid-cols-2">
+          <UCard>
+            <template #header>
+              <div class="flex items-center justify-between">
+                <h2 class="font-semibold">
+                  Tool calls
+                </h2>
+                <UButton
+                  size="xs"
+                  color="neutral"
+                  variant="ghost"
+                  icon="i-lucide-trash-2"
+                  @click="tester.clearCalls()"
+                >
+                  Clear
+                </UButton>
+              </div>
+            </template>
+            <div
+              v-if="tester.toolCalls.value.length === 0"
+              class="py-8 text-center text-sm text-muted"
             >
-              <div class="flex items-center justify-between gap-2">
-                <span class="font-mono text-xs font-semibold">{{ entry.tool }}</span>
-                <span class="text-[10px] uppercase text-dimmed">{{ formatTime(entry.startedAt) }}</span>
-              </div>
-              <pre
-                v-if="Object.keys(entry.args).length"
-                class="mt-2 overflow-x-auto rounded bg-default/60 p-2 text-[11px]"
-              >{{ JSON.stringify(entry.args) }}</pre>
-              <div
-                v-if="entry.finishedAt"
-                class="mt-2 whitespace-pre-wrap rounded text-xs"
-                :class="entry.error ? 'text-error' : 'text-default'"
+              No calls yet. Pick a tool above and hit Run.
+            </div>
+            <ul class="space-y-3">
+              <li
+                v-for="entry in tester.toolCalls.value"
+                :key="entry.id"
+                class="rounded-md border border-default bg-elevated/40 p-3"
               >
-                {{ formatResult(entry) }}
+                <div class="flex items-center justify-between gap-2">
+                  <span class="font-mono text-xs font-semibold">{{ entry.tool }}</span>
+                  <span class="text-[10px] uppercase text-dimmed">{{ formatTime(entry.startedAt) }}</span>
+                </div>
+                <pre
+                  v-if="Object.keys(entry.args).length"
+                  class="mt-2 overflow-x-auto rounded bg-default/60 p-2 text-[11px]"
+                >{{ JSON.stringify(entry.args) }}</pre>
+                <div
+                  v-if="entry.finishedAt"
+                  class="mt-2 whitespace-pre-wrap rounded text-xs"
+                  :class="entry.error ? 'text-error' : 'text-default'"
+                >
+                  {{ formatResult(entry) }}
+                </div>
+                <UBadge
+                  v-else
+                  color="warning"
+                  variant="subtle"
+                  size="xs"
+                  icon="i-lucide-loader"
+                  class="mt-2"
+                >
+                  pending
+                </UBadge>
+              </li>
+            </ul>
+          </UCard>
+
+          <UCard>
+            <template #header>
+              <div class="flex items-center justify-between">
+                <h2 class="font-semibold">
+                  Notifications
+                  <span class="text-xs font-normal text-muted">(notifications/message)</span>
+                </h2>
+                <UButton
+                  size="xs"
+                  color="neutral"
+                  variant="ghost"
+                  icon="i-lucide-trash-2"
+                  @click="tester.clearNotifications()"
+                >
+                  Clear
+                </UButton>
               </div>
-              <UBadge
-                v-else
-                color="warning"
-                variant="subtle"
-                size="xs"
-                icon="i-lucide-loader"
-                class="mt-2"
+            </template>
+            <div
+              v-if="tester.notifications.value.length === 0"
+              class="py-8 text-center text-sm text-muted"
+            >
+              No notifications yet. Run <span class="font-mono">observability_demo</span> to stream a few.
+            </div>
+            <ul class="space-y-2">
+              <li
+                v-for="entry in tester.notifications.value"
+                :key="entry.id"
+                class="rounded-md border border-default bg-elevated/40 p-2"
               >
-                pending
-              </UBadge>
-            </li>
-          </ul>
-        </UCard>
+                <div class="flex items-center gap-2">
+                  <UBadge
+                    :color="levelColor(entry.level)"
+                    variant="subtle"
+                    size="xs"
+                  >
+                    {{ entry.level }}
+                  </UBadge>
+                  <span
+                    v-if="entry.logger"
+                    class="font-mono text-[10px] text-muted"
+                  >{{ entry.logger }}</span>
+                  <span class="ml-auto text-[10px] text-dimmed">{{ formatTime(entry.receivedAt) }}</span>
+                </div>
+                <pre class="mt-1 overflow-x-auto whitespace-pre-wrap text-[11px]">{{ JSON.stringify(entry.data, null, 2) }}</pre>
+              </li>
+            </ul>
+          </UCard>
+        </div>
 
         <UCard v-if="otherTools.length">
           <template #header>

--- a/apps/playground/nuxt.config.ts
+++ b/apps/playground/nuxt.config.ts
@@ -57,5 +57,8 @@ export default defineNuxtConfig({
     description: 'A demo MCP server showcasing authentication, todos, and user management.',
     instructions: 'Authenticate with an API key before calling protected tools. Use list-todos before create-todo to avoid duplicates.',
     sessions: true,
+    logging: {
+      env: { environment: 'development' },
+    },
   },
 })

--- a/apps/playground/server/mcp/tools/observability-demo.ts
+++ b/apps/playground/server/mcp/tools/observability-demo.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+
+export default defineMcpTool({
+  name: 'observability_demo',
+  description: 'Demo logger: stream notifications to the client AND tag the server-side wide event',
+  inputSchema: {
+    label: z.string().describe('Label to attach to the server-side wide event'),
+  },
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: false,
+  },
+  handler: async ({ label }) => {
+    const log = useMcpLogger('demo')
+
+    // → MCP CLIENT: shows up in the Inspector "Server Notifications" panel
+    //   (and the AI client's log viewer). Honours `logging/setLevel`.
+    await log.notify.info({ msg: 'observability_demo started', label })
+    await log.notify.warning({ msg: 'this is a sample warning' })
+
+    // → SERVER TERMINAL: merged into the request's evlog wide event and
+    //   pretty-printed once the response is sent. Drains pick this up too.
+    log.set({ demo: { label } })
+    log.event('work_done', { duration: 42 })
+
+    return `Sent 2 client notifications and tagged the wide event with label "${label}". Check your dev terminal for the merged wide event.`
+  },
+})

--- a/packages/nuxt-mcp-toolkit/package.json
+++ b/packages/nuxt-mcp-toolkit/package.json
@@ -51,13 +51,14 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@nuxt/kit": "^4.4.2",
+    "evlog": "^2.13.0",
     "tinyglobby": "^0.2.16"
   },
   "peerDependencies": {
-    "h3": ">=1.15.11",
-    "zod": "^4.1.13",
     "agents": ">=0.11.4",
-    "secure-exec": ">=0.2.1"
+    "h3": ">=1.15.11",
+    "secure-exec": ">=0.2.1",
+    "zod": "^4.1.13"
   },
   "peerDependenciesMeta": {
     "h3": {

--- a/packages/nuxt-mcp-toolkit/package.json
+++ b/packages/nuxt-mcp-toolkit/package.json
@@ -51,11 +51,11 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@nuxt/kit": "^4.4.2",
-    "evlog": "^2.13.0",
     "tinyglobby": "^0.2.16"
   },
   "peerDependencies": {
     "agents": ">=0.11.4",
+    "evlog": "^2.13.0",
     "h3": ">=1.15.11",
     "secure-exec": ">=0.2.1",
     "zod": "^4.1.13"
@@ -70,6 +70,9 @@
     "agents": {
       "optional": true
     },
+    "evlog": {
+      "optional": true
+    },
     "secure-exec": {
       "optional": true
     }
@@ -82,6 +85,7 @@
     "@nuxt/test-utils": "^4.0.2",
     "@types/node": "latest",
     "eslint": "^9.39.4",
+    "evlog": "^2.13.0",
     "nuxt": "^4.4.2",
     "typescript": "~6.0.3",
     "vitest": "^4.1.4",

--- a/packages/nuxt-mcp-toolkit/src/module.ts
+++ b/packages/nuxt-mcp-toolkit/src/module.ts
@@ -1,6 +1,5 @@
 import { createRequire } from 'node:module'
 import { defineNuxtModule, addServerHandler, addServerTemplate, createResolver, addServerImports, addComponent, logger } from '@nuxt/kit'
-import type { NitroModuleOptions } from 'evlog/nitro'
 import { loadAllDefinitions } from './runtime/server/mcp/loaders'
 import { defaultMcpConfig, getMcpConfig } from './runtime/server/mcp/config'
 import { ROUTES } from './runtime/server/mcp/constants'
@@ -110,22 +109,25 @@ export interface ModuleOptions {
    */
   security?: McpSecurityConfig
   /**
-   * Server-side logging configuration powered by [evlog](https://evlog.dev).
+   * Server-side observability powered by the optional [evlog](https://evlog.dev) peer dependency.
    *
-   * The toolkit ships evlog as a direct dependency and registers its Nitro
-   * module automatically so `useMcpLogger().set()`, `.event()`, and `.evlog`
-   * feed structured wide events for every MCP request.
+   * Behavior:
+   * - `undefined` (default): **auto-detect**. If `evlog` is installed, it is
+   *   wired into Nitro automatically and `useMcpLogger().set()` / `.event()` /
+   *   `.evlog` start feeding the request-scoped wide event. Otherwise it stays
+   *   off — only `useMcpLogger().notify(...)` (the client channel) works.
+   * - `true`: force on. If `evlog` is not installed, the build throws with
+   *   install instructions.
+   * - object: force on with options forwarded to the evlog Nitro module.
+   *   Same install requirement as `true`.
+   * - `false`: force off. `set()` / `event()` / `evlog` throw on use.
    *
-   * Pass `false` to disable the integration entirely (the `useMcpLogger()`
-   * composable still works for `notify()` calls — it just won't emit wide
-   * events). Pass an object to forward options to the evlog Nitro module.
-   *
-   * @default true
    * @see https://evlog.dev
    */
-  logging?: false | (NitroModuleOptions & {
+  logging?: boolean | ({
     /** Service name advertised on every wide event. Defaults to `options.name || 'mcp-server'`. */
     service?: string
+    [key: string]: unknown
   })
 }
 
@@ -166,18 +168,42 @@ export default defineNuxtModule<ModuleOptions>({
       nitroOptions.storage['mcp:sessions-meta'] ??= { driver: 'memory' }
     }
 
-    const loggingEnabled = options.logging !== false
-    if (loggingEnabled && nitroOptions) {
-      const { default: evlogNitro } = await import('evlog/nitro')
+    const loggingExplicit = options.logging !== undefined
+    const loggingForcedOff = options.logging === false
+    const loggingForcedOn = options.logging === true || (typeof options.logging === 'object' && options.logging !== null)
+
+    let evlogAvailable = false
+    if (!loggingForcedOff) {
+      try {
+        const moduleRequire = createRequire(import.meta.url)
+        moduleRequire.resolve('evlog/nitro')
+        evlogAvailable = true
+      }
+      catch {
+        // evlog not installed — fall through. Only an error if explicitly forced on.
+      }
+    }
+
+    if (loggingForcedOn && !evlogAvailable) {
+      throw new Error(
+        '[@nuxtjs/mcp-toolkit] `mcp.logging` is enabled but the optional `evlog` peer dependency is not installed. '
+        + 'Run `pnpm add evlog` (or `npm install evlog` / `yarn add evlog` / `bun add evlog`) to enable server-side observability, '
+        + 'or set `mcp.logging: false` to opt out.',
+      )
+    }
+
+    const loggingActive = evlogAvailable && !loggingForcedOff
+    if (loggingActive && nitroOptions) {
+      const { default: evlogNitro } = await import('evlog/nitro') as typeof import('evlog/nitro')
       const loggingOptions = (typeof options.logging === 'object' && options.logging) || {}
-      const { service, ...evlogOptions } = loggingOptions
+      const { service, ...evlogOptions } = loggingOptions as { service?: string, env?: Record<string, unknown>, [key: string]: unknown }
       const resolvedService = service ?? options.name ?? 'mcp-server'
 
       const evlogModule = evlogNitro({
         ...evlogOptions,
         env: {
-          ...evlogOptions.env,
-          service: evlogOptions.env?.service ?? resolvedService,
+          ...(evlogOptions.env as Record<string, unknown> | undefined),
+          service: (evlogOptions.env as { service?: string } | undefined)?.service ?? resolvedService,
         },
       })
 
@@ -214,6 +240,14 @@ export default defineNuxtModule<ModuleOptions>({
           nitroConfig.modules.push(wrappedEvlogModule)
         }
       })
+
+      log.info(`Observability enabled · evlog wide events on \`${options.route ?? '/mcp'}\``)
+    }
+    else if (loggingExplicit && loggingForcedOff) {
+      log.info('Observability disabled (`mcp.logging: false`) · `useMcpLogger().notify` still active')
+    }
+    else if (!evlogAvailable) {
+      log.info('Observability inactive · install `evlog` to enable wide-event tracing — `useMcpLogger().notify` still works')
     }
 
     if (options.autoImports !== false) {

--- a/packages/nuxt-mcp-toolkit/src/module.ts
+++ b/packages/nuxt-mcp-toolkit/src/module.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module'
 import { defineNuxtModule, addServerHandler, addServerTemplate, createResolver, addServerImports, addComponent, logger } from '@nuxt/kit'
+import type { NitroModuleOptions } from 'evlog/nitro'
 import { loadAllDefinitions } from './runtime/server/mcp/loaders'
 import { defaultMcpConfig, getMcpConfig } from './runtime/server/mcp/config'
 import { ROUTES } from './runtime/server/mcp/constants'
@@ -108,6 +109,24 @@ export interface ModuleOptions {
    * @see https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning
    */
   security?: McpSecurityConfig
+  /**
+   * Server-side logging configuration powered by [evlog](https://evlog.dev).
+   *
+   * The toolkit ships evlog as a direct dependency and registers its Nitro
+   * module automatically so `useMcpLogger().set()`, `.event()`, and `.evlog`
+   * feed structured wide events for every MCP request.
+   *
+   * Pass `false` to disable the integration entirely (the `useMcpLogger()`
+   * composable still works for `notify()` calls — it just won't emit wide
+   * events). Pass an object to forward options to the evlog Nitro module.
+   *
+   * @default true
+   * @see https://evlog.dev
+   */
+  logging?: false | (NitroModuleOptions & {
+    /** Service name advertised on every wide event. Defaults to `options.name || 'mcp-server'`. */
+    service?: string
+  })
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -145,6 +164,56 @@ export default defineNuxtModule<ModuleOptions>({
       nitroOptions.storage ??= {}
       nitroOptions.storage['mcp:sessions'] ??= { driver: 'memory' }
       nitroOptions.storage['mcp:sessions-meta'] ??= { driver: 'memory' }
+    }
+
+    const loggingEnabled = options.logging !== false
+    if (loggingEnabled && nitroOptions) {
+      const { default: evlogNitro } = await import('evlog/nitro')
+      const loggingOptions = (typeof options.logging === 'object' && options.logging) || {}
+      const { service, ...evlogOptions } = loggingOptions
+      const resolvedService = service ?? options.name ?? 'mcp-server'
+
+      const evlogModule = evlogNitro({
+        ...evlogOptions,
+        env: {
+          ...evlogOptions.env,
+          service: evlogOptions.env?.service ?? resolvedService,
+        },
+      })
+
+      // Wrap the evlog module so we can roll back its `noExternals: true` flag
+      // after setup. evlog forces bundling of its runtime, but that flag also
+      // tries to bundle every other dependency (`drizzle-kit`, native modules,
+      // …) which breaks integrations like `@nuxthub/core`. We just need
+      // evlog's *own* package inlined, so we reset the global flag and add
+      // evlog to the inline list instead. The MCP-specific context tagging
+      // happens directly in `createMcpHandler` (see `runtime/server/mcp/utils`),
+      // so we don't need a separate Nitro plugin here — that avoids ordering
+      // issues with evlog's own request hook.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const wrappedEvlogModule: any = {
+        name: 'evlog',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        async setup(nitro: any) {
+          const previousNoExternals = nitro.options.noExternals
+          await evlogModule.setup?.(nitro)
+          nitro.options.noExternals = previousNoExternals ?? false
+          nitro.options.externals ??= {}
+          nitro.options.externals.inline = Array.from(new Set([
+            ...(nitro.options.externals.inline ?? []),
+            'evlog',
+            'evlog/nitro',
+          ]))
+        },
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(nuxt.hook as any)('nitro:config', (nitroConfig: any) => {
+        nitroConfig.modules ??= []
+        if (!nitroConfig.modules.some((m: unknown) => typeof m === 'object' && m !== null && 'name' in m && (m as { name: string }).name === 'evlog')) {
+          nitroConfig.modules.push(wrappedEvlogModule)
+        }
+      })
     }
 
     if (options.autoImports !== false) {
@@ -296,6 +365,7 @@ export default defineNuxtModule<ModuleOptions>({
     const mcpSessionPath = resolver.resolve('runtime/server/mcp/session')
     const mcpServerPath = resolver.resolve('runtime/server/mcp/server')
     const mcpElicitationPath = resolver.resolve('runtime/server/mcp/elicitation')
+    const mcpLoggerPath = resolver.resolve('runtime/server/mcp/logger')
 
     if (options.autoImports !== false) {
       addServerImports([
@@ -324,6 +394,7 @@ export default defineNuxtModule<ModuleOptions>({
         { name: 'invalidateMcpSession', from: mcpSessionPath },
         { name: 'useMcpServer', from: mcpServerPath },
         { name: 'useMcpElicitation', from: mcpElicitationPath },
+        { name: 'useMcpLogger', from: mcpLoggerPath },
       ])
     }
 

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/index.ts
@@ -24,6 +24,9 @@ export type {
   McpElicitation,
 } from '../elicitation'
 
+export { useMcpLogger } from '../logger'
+export type { McpLogger } from '../logger'
+
 /** Commonly used MCP protocol types from `@modelcontextprotocol/sdk` (single import path with the toolkit). */
 export type {
   Annotations,

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/index.ts
@@ -24,8 +24,8 @@ export type {
   McpElicitation,
 } from '../elicitation'
 
-export { useMcpLogger } from '../logger'
-export type { McpLogger } from '../logger'
+export { useMcpLogger, McpObservabilityNotEnabledError } from '../logger'
+export type { McpClientNotifier, McpLogger, McpRequestLogger } from '../logger'
 
 /** Commonly used MCP protocol types from `@modelcontextprotocol/sdk` (single import path with the toolkit). */
 export type {

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/logger.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/logger.ts
@@ -1,0 +1,165 @@
+import type { LoggingLevel } from '@modelcontextprotocol/sdk/types.js'
+import type { RequestLogger } from 'evlog'
+import { useEvent } from 'nitropack/runtime'
+import { useLogger as useEvlogLogger } from 'evlog/nitro'
+import { getHeader } from './compat'
+import { useMcpServer } from './server'
+
+/**
+ * Methods that send `notifications/message` to the connected MCP client
+ * (Cursor, Claude Desktop, MCP Inspector, ...). They respect the level
+ * the client opted into via `logging/setLevel` and are silently dropped
+ * when the transport is gone.
+ *
+ * **These never appear in your terminal** — they go over the wire to
+ * whoever is connected. Use `log.set()` / `log.event()` for server-side
+ * observability.
+ */
+export interface McpClientNotifier {
+  /** Send a `notifications/message` at an arbitrary level. */
+  (level: LoggingLevel, data: unknown, logger?: string): Promise<void>
+  /** Shortcut for `notify('debug', ...)`. */
+  debug: (data: unknown, logger?: string) => Promise<void>
+  /** Shortcut for `notify('info', ...)`. */
+  info: (data: unknown, logger?: string) => Promise<void>
+  /** Shortcut for `notify('warning', ...)`. */
+  warning: (data: unknown, logger?: string) => Promise<void>
+  /** Shortcut for `notify('error', ...)`. */
+  error: (data: unknown, logger?: string) => Promise<void>
+}
+
+/**
+ * Split-channel logger for MCP servers.
+ *
+ * Two clearly separated channels:
+ *
+ * - `log.notify(...)` (and `.notify.info`, `.notify.warning`, ...): **client
+ *   notifications** sent over the MCP transport. Visible in the MCP
+ *   Inspector "Server Notifications" panel and to AI clients. Honours the
+ *   per-session `logging/setLevel`.
+ * - `log.set(...)` / `log.event(...)`: **server-side wide event** fed to
+ *   evlog. Pretty-printed in the dev terminal at the end of each request,
+ *   shipped to drains (Axiom, Sentry, OTLP, ...) in production. Operator
+ *   facing.
+ *
+ * Pick the channel based on the audience: end-users / AI client → `notify`,
+ * operators / dashboards → `set` + `event`.
+ */
+export interface McpLogger {
+  /**
+   * Send a `notifications/message` to the connected MCP client.
+   * Use `log.notify.info(...)` (and friends) for the common levels.
+   */
+  notify: McpClientNotifier
+
+  /** Accumulate context onto the current request's evlog wide event. */
+  set: (fields: Record<string, unknown>) => void
+  /**
+   * Append a discrete entry to the wide event's `requestLogs` and merge
+   * any extra fields. Equivalent to `evlog.info(name, fields)`.
+   */
+  event: (name: string, fields?: Record<string, unknown>) => void
+  /** Underlying evlog request logger for advanced use (`fork`, `error`, …). */
+  evlog: RequestLogger
+}
+
+const noopEvlog: RequestLogger = {
+  set: () => {},
+  error: () => {},
+  info: () => {},
+  warn: () => {},
+  emit: () => null,
+  getContext: () => ({}),
+}
+
+function safeEvlog(): RequestLogger {
+  try {
+    const event = useEvent()
+    return useEvlogLogger(event)
+  }
+  catch {
+    return noopEvlog
+  }
+}
+
+/**
+ * Composable returning a split-channel logger bound to the current request.
+ *
+ * Must be called inside an MCP tool, resource, or prompt handler. Requires
+ * `nitro.experimental.asyncContext: true`.
+ *
+ * The optional `prefix` becomes the default `logger` field on every
+ * `notifications/message` so the client can group related log lines.
+ *
+ * @example
+ * ```ts
+ * const log = useMcpLogger('billing')
+ *
+ * // → MCP client (Inspector, Cursor, …)
+ * await log.notify.info({ msg: 'starting charge', amount: 1000 })
+ *
+ * // → server terminal / evlog drains
+ * log.set({ user: { id: ctx.userId } })
+ * log.event('charge_started', { amount: 1000 })
+ * ```
+ */
+export function useMcpLogger(prefix?: string): McpLogger {
+  const helper = useMcpServer()
+  // The high-level `McpServer` exposes the underlying SDK `Server` via `.server`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sdkServer = (helper.server as any).server as {
+    sendLoggingMessage: (params: { level: LoggingLevel, data: unknown, logger?: string }, sessionId?: string) => Promise<void>
+  }
+
+  const evlog = safeEvlog()
+  // The SDK tracks `logging/setLevel` per session id, so we must forward the
+  // current MCP session header to `sendLoggingMessage` for filtering to apply.
+  let sessionId: string | undefined
+  try {
+    const event = useEvent()
+    sessionId = getHeader(event, 'mcp-session-id') ?? undefined
+  }
+  catch {
+    // Outside of a request scope (e.g., bootstrap) — sessionId stays undefined.
+  }
+
+  const sendNotify = async (level: LoggingLevel, data: unknown, logger?: string): Promise<void> => {
+    try {
+      await sdkServer.sendLoggingMessage({
+        level,
+        data,
+        logger: logger ?? prefix,
+      }, sessionId)
+    }
+    catch (err) {
+      // Disconnected client / unsubscribed level / no transport — never throw.
+      try {
+        evlog.warn('mcp logger notify failed', {
+          mcp: { logger: logger ?? prefix, level },
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+      catch {
+        // Evlog drain itself failed — stay silent to honor the no-throw contract.
+      }
+    }
+  }
+
+  // The notifier is a callable + level shortcuts so both styles read well.
+  const notify = sendNotify as McpClientNotifier
+  notify.debug = (data, logger) => sendNotify('debug', data, logger)
+  notify.info = (data, logger) => sendNotify('info', data, logger)
+  notify.warning = (data, logger) => sendNotify('warning', data, logger)
+  notify.error = (data, logger) => sendNotify('error', data, logger)
+
+  return {
+    notify,
+    set: (fields) => {
+      evlog.set(fields)
+    },
+    event: (name, fields) => {
+      evlog.info(name, fields)
+    },
+    evlog,
+  }
+}

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/logger.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/logger.ts
@@ -1,7 +1,6 @@
 import type { LoggingLevel } from '@modelcontextprotocol/sdk/types.js'
-import type { RequestLogger } from 'evlog'
 import { useEvent } from 'nitropack/runtime'
-import { useLogger as useEvlogLogger } from 'evlog/nitro'
+import type { H3Event } from 'h3'
 import { getHeader } from './compat'
 import { useMcpServer } from './server'
 
@@ -29,6 +28,21 @@ export interface McpClientNotifier {
 }
 
 /**
+ * Minimal shape of evlog's per-request logger. Kept structural so the
+ * toolkit doesn't pull `evlog` into its public types — users get the
+ * full type signature only when they install `evlog` themselves.
+ */
+export interface McpRequestLogger {
+  set: (fields: Record<string, unknown>) => void
+  info: (name: string, fields?: Record<string, unknown>) => void
+  warn: (name: string, fields?: Record<string, unknown>) => void
+  error: (name: string, fields?: Record<string, unknown>) => void
+  getContext: () => Record<string, unknown>
+  emit?: (...args: unknown[]) => unknown
+  fork?: (...args: unknown[]) => unknown
+}
+
+/**
  * Split-channel logger for MCP servers.
  *
  * Two clearly separated channels:
@@ -36,14 +50,12 @@ export interface McpClientNotifier {
  * - `log.notify(...)` (and `.notify.info`, `.notify.warning`, ...): **client
  *   notifications** sent over the MCP transport. Visible in the MCP
  *   Inspector "Server Notifications" panel and to AI clients. Honours the
- *   per-session `logging/setLevel`.
+ *   per-session `logging/setLevel`. Always available, even without evlog.
  * - `log.set(...)` / `log.event(...)`: **server-side wide event** fed to
  *   evlog. Pretty-printed in the dev terminal at the end of each request,
  *   shipped to drains (Axiom, Sentry, OTLP, ...) in production. Operator
- *   facing.
- *
- * Pick the channel based on the audience: end-users / AI client → `notify`,
- * operators / dashboards → `set` + `event`.
+ *   facing. Requires the optional `evlog` peer dependency to be installed
+ *   and `mcp.logging` not explicitly disabled.
  */
 export interface McpLogger {
   /**
@@ -52,33 +64,64 @@ export interface McpLogger {
    */
   notify: McpClientNotifier
 
-  /** Accumulate context onto the current request's evlog wide event. */
+  /**
+   * Accumulate context onto the current request's evlog wide event.
+   *
+   * @throws when observability is not active on this request — install
+   * the optional `evlog` peer dependency and make sure `mcp.logging` is
+   * not set to `false`.
+   */
   set: (fields: Record<string, unknown>) => void
   /**
    * Append a discrete entry to the wide event's `requestLogs` and merge
    * any extra fields. Equivalent to `evlog.info(name, fields)`.
+   *
+   * @throws when observability is not active on this request — see `set`.
    */
   event: (name: string, fields?: Record<string, unknown>) => void
-  /** Underlying evlog request logger for advanced use (`fork`, `error`, …). */
-  evlog: RequestLogger
+  /**
+   * Underlying evlog request logger for advanced use (`fork`, `error`, …).
+   *
+   * @throws when observability is not active on this request — see `set`.
+   */
+  evlog: McpRequestLogger
 }
 
-const noopEvlog: RequestLogger = {
-  set: () => {},
-  error: () => {},
-  info: () => {},
-  warn: () => {},
-  emit: () => null,
-  getContext: () => ({}),
+const OBSERVABILITY_HINT
+  = 'Server-side observability is not active on this request. '
+    + 'Install the optional `evlog` peer dependency (`pnpm add evlog`) '
+    + 'and make sure `mcp.logging` is not set to `false` in nuxt.config. '
+    + '`log.notify.*` (client channel) keeps working without evlog.'
+
+class McpObservabilityNotEnabledError extends Error {
+  constructor() {
+    super(OBSERVABILITY_HINT)
+    this.name = 'McpObservabilityNotEnabledError'
+  }
 }
 
-function safeEvlog(): RequestLogger {
+function getRequestLogger(event: H3Event | null): McpRequestLogger | null {
+  if (!event) return null
+  // evlog's Nitro request plugin assigns the per-request logger here.
+  // Duck-typed so we don't import from `evlog` (it's an optional peer dep).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const candidate = (event.context as any).log as Partial<McpRequestLogger> | undefined
+  if (
+    candidate
+    && typeof candidate.set === 'function'
+    && typeof candidate.info === 'function'
+  ) {
+    return candidate as McpRequestLogger
+  }
+  return null
+}
+
+function safeEvent(): H3Event | null {
   try {
-    const event = useEvent()
-    return useEvlogLogger(event)
+    return useEvent()
   }
   catch {
-    return noopEvlog
+    return null
   }
 }
 
@@ -95,10 +138,10 @@ function safeEvlog(): RequestLogger {
  * ```ts
  * const log = useMcpLogger('billing')
  *
- * // → MCP client (Inspector, Cursor, …)
+ * // → MCP client (Inspector, Cursor, …) — always works
  * await log.notify.info({ msg: 'starting charge', amount: 1000 })
  *
- * // → server terminal / evlog drains
+ * // → server terminal / evlog drains — requires `evlog` installed
  * log.set({ user: { id: ctx.userId } })
  * log.event('charge_started', { amount: 1000 })
  * ```
@@ -111,17 +154,12 @@ export function useMcpLogger(prefix?: string): McpLogger {
     sendLoggingMessage: (params: { level: LoggingLevel, data: unknown, logger?: string }, sessionId?: string) => Promise<void>
   }
 
-  const evlog = safeEvlog()
+  const event = safeEvent()
+  const requestLogger = getRequestLogger(event)
+
   // The SDK tracks `logging/setLevel` per session id, so we must forward the
   // current MCP session header to `sendLoggingMessage` for filtering to apply.
-  let sessionId: string | undefined
-  try {
-    const event = useEvent()
-    sessionId = getHeader(event, 'mcp-session-id') ?? undefined
-  }
-  catch {
-    // Outside of a request scope (e.g., bootstrap) — sessionId stays undefined.
-  }
+  const sessionId = event ? (getHeader(event, 'mcp-session-id') ?? undefined) : undefined
 
   const sendNotify = async (level: LoggingLevel, data: unknown, logger?: string): Promise<void> => {
     try {
@@ -133,33 +171,43 @@ export function useMcpLogger(prefix?: string): McpLogger {
     }
     catch (err) {
       // Disconnected client / unsubscribed level / no transport — never throw.
-      try {
-        evlog.warn('mcp logger notify failed', {
-          mcp: { logger: logger ?? prefix, level },
-          error: err instanceof Error ? err.message : String(err),
-        })
-      }
-      catch {
-        // Evlog drain itself failed — stay silent to honor the no-throw contract.
+      if (requestLogger) {
+        try {
+          requestLogger.warn('mcp logger notify failed', {
+            mcp: { logger: logger ?? prefix, level },
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+        catch {
+          // Drain itself failed — stay silent to honor the no-throw contract.
+        }
       }
     }
   }
 
-  // The notifier is a callable + level shortcuts so both styles read well.
   const notify = sendNotify as McpClientNotifier
   notify.debug = (data, logger) => sendNotify('debug', data, logger)
   notify.info = (data, logger) => sendNotify('info', data, logger)
   notify.warning = (data, logger) => sendNotify('warning', data, logger)
   notify.error = (data, logger) => sendNotify('error', data, logger)
 
+  const requireRequestLogger = (): McpRequestLogger => {
+    if (!requestLogger) throw new McpObservabilityNotEnabledError()
+    return requestLogger
+  }
+
   return {
     notify,
     set: (fields) => {
-      evlog.set(fields)
+      requireRequestLogger().set(fields)
     },
     event: (name, fields) => {
-      evlog.info(name, fields)
+      requireRequestLogger().info(name, fields)
     },
-    evlog,
+    get evlog() {
+      return requireRequestLogger()
+    },
   }
 }
+
+export { McpObservabilityNotEnabledError }

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/utils.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/utils.ts
@@ -1,5 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { eventHandler, sendRedirect } from 'h3'
+import { eventHandler, readBody, sendRedirect } from 'h3'
 import type { H3Event } from 'h3'
 import type { McpMiddleware, McpIcon } from './definitions/handlers'
 import type { McpPromptDefinition } from './definitions/prompts'
@@ -114,6 +114,9 @@ export async function createMcpServer(config: StaticMcpConfig): Promise<McpServe
     icons: config.icons,
   }, {
     instructions: config.instructions,
+    capabilities: {
+      logging: {},
+    },
   })
 
   let toolsToRegister: McpToolDefinition[] = config.tools as McpToolDefinition[]
@@ -141,9 +144,115 @@ export async function createMcpServer(config: StaticMcpConfig): Promise<McpServe
   return server
 }
 
+interface JsonRpcMessage {
+  method?: unknown
+  id?: unknown
+  params?: Record<string, unknown> | null
+}
+
+interface RpcSummary {
+  methods: string[]
+  ids: (string | number)[]
+  tools: string[]
+  resources: string[]
+  prompts: string[]
+}
+
+function summarizeRpcBody(body: unknown): RpcSummary | undefined {
+  if (!body) return undefined
+  const messages = (Array.isArray(body) ? body : [body]) as JsonRpcMessage[]
+  const summary: RpcSummary = {
+    methods: [],
+    ids: [],
+    tools: [],
+    resources: [],
+    prompts: [],
+  }
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== 'object') continue
+    if (typeof msg.method === 'string') summary.methods.push(msg.method)
+    if (typeof msg.id === 'string' || typeof msg.id === 'number') summary.ids.push(msg.id)
+
+    const params = msg.params
+    if (params && typeof params === 'object') {
+      const name = typeof params.name === 'string' ? params.name : undefined
+      const uri = typeof params.uri === 'string' ? params.uri : undefined
+      if (msg.method === 'tools/call' && name) summary.tools.push(name)
+      if (msg.method === 'resources/read' && uri) summary.resources.push(uri)
+      if (msg.method === 'prompts/get' && name) summary.prompts.push(name)
+    }
+  }
+
+  if (
+    !summary.methods.length
+    && !summary.tools.length
+    && !summary.resources.length
+    && !summary.prompts.length
+    && !summary.ids.length
+  ) return undefined
+
+  return summary
+}
+
+function pickOne<T>(values: T[]): T | T[] | undefined {
+  if (!values.length) return undefined
+  if (values.length === 1) return values[0]
+  return values
+}
+
+/**
+ * Tag the request-scoped evlog wide event with MCP-specific context.
+ *
+ * Captures session, transport, route, and (when the body is a JSON-RPC
+ * payload) the method, request id, and tool/resource/prompt names. Runs
+ * from the handler so it executes after evlog's `request` plugin has
+ * populated `event.context.log`, regardless of plugin ordering.
+ */
+async function tagEvlogContext(event: H3Event, route: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const log = (event.context as any).log as { set?: (data: Record<string, unknown>) => void } | undefined
+  if (!log?.set) return
+
+  const sessionId = getHeader(event, 'mcp-session-id')
+  const mcp: Record<string, unknown> = {
+    transport: 'streamable-http',
+    route,
+  }
+  if (sessionId) mcp.session_id = sessionId
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const method = (event as any).method ?? (event as any).node?.req?.method
+  if (typeof method === 'string' && method.toUpperCase() === 'POST') {
+    let summary: RpcSummary | undefined
+    try {
+      summary = summarizeRpcBody(await readBody(event))
+    }
+    catch {
+      // Body unreadable / not JSON — skip enrichment
+    }
+
+    if (summary) {
+      const m = pickOne(summary.methods)
+      const id = pickOne(summary.ids)
+      const tool = pickOne(summary.tools)
+      const resource = pickOne(summary.resources)
+      const prompt = pickOne(summary.prompts)
+      if (m !== undefined) mcp[Array.isArray(m) ? 'methods' : 'method'] = m
+      if (id !== undefined) mcp[Array.isArray(id) ? 'request_ids' : 'request_id'] = id
+      if (tool !== undefined) mcp[Array.isArray(tool) ? 'tools' : 'tool'] = tool
+      if (resource !== undefined) mcp[Array.isArray(resource) ? 'resources' : 'resource'] = resource
+      if (prompt !== undefined) mcp[Array.isArray(prompt) ? 'prompts' : 'prompt'] = prompt
+    }
+  }
+
+  log.set({ mcp })
+}
+
 export function createMcpHandler(config: CreateMcpHandlerConfig) {
   return eventHandler(async (event: H3Event) => {
     const resolvedConfig = resolveConfig(config, event)
+    await tagEvlogContext(event, event.path?.split('?')[0] || '/mcp')
 
     if (getHeader(event, 'accept')?.includes('text/html')) {
       return sendRedirect(event, resolvedConfig.browserRedirect)

--- a/packages/nuxt-mcp-toolkit/test/fixtures/logger-disabled/app.vue
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/logger-disabled/app.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>logger-disabled</div>
+</template>
+
+<script setup>
+</script>

--- a/packages/nuxt-mcp-toolkit/test/fixtures/logger-disabled/nuxt.config.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/logger-disabled/nuxt.config.ts
@@ -1,0 +1,16 @@
+import MyModule from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    MyModule,
+  ],
+  nitro: {
+    experimental: {
+      asyncContext: true,
+    },
+  },
+  mcp: {
+    sessions: true,
+    logging: false,
+  },
+})

--- a/packages/nuxt-mcp-toolkit/test/fixtures/logger-disabled/package.json
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/logger-disabled/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "mcp-toolkit-logger-disabled-fixture",
+  "private": true
+}

--- a/packages/nuxt-mcp-toolkit/test/fixtures/logger-disabled/server/mcp/tools/notify-only.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/logger-disabled/server/mcp/tools/notify-only.ts
@@ -1,0 +1,38 @@
+import { defineMcpTool } from '../../../../../../src/runtime/server/types'
+import { useMcpLogger } from '../../../../../../src/runtime/server/mcp/logger'
+
+export default defineMcpTool({
+  name: 'notify_only',
+  description: 'Verifies notify works without observability and that set/event throw',
+  inputSchema: {},
+  handler: async () => {
+    const log = useMcpLogger('disabled-fixture')
+
+    await log.notify.info({ msg: 'notify still works without evlog' })
+
+    let setError: string | null = null
+    try {
+      log.set({ should: 'throw' })
+    }
+    catch (err) {
+      setError = err instanceof Error ? err.name : String(err)
+    }
+
+    let eventError: string | null = null
+    try {
+      log.event('should_throw')
+    }
+    catch (err) {
+      eventError = err instanceof Error ? err.name : String(err)
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ setError, eventError }),
+        },
+      ],
+    }
+  },
+})

--- a/packages/nuxt-mcp-toolkit/test/fixtures/logger/app.vue
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/logger/app.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>logger</div>
+</template>
+
+<script setup>
+</script>

--- a/packages/nuxt-mcp-toolkit/test/fixtures/logger/nuxt.config.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/logger/nuxt.config.ts
@@ -1,0 +1,18 @@
+import MyModule from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    MyModule,
+  ],
+  nitro: {
+    experimental: {
+      asyncContext: true,
+    },
+  },
+  mcp: {
+    sessions: true,
+    logging: {
+      silent: true,
+    },
+  },
+})

--- a/packages/nuxt-mcp-toolkit/test/fixtures/logger/package.json
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/logger/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "mcp-toolkit-logger-fixture",
+  "private": true
+}

--- a/packages/nuxt-mcp-toolkit/test/fixtures/logger/server/mcp/tools/notify-all.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/logger/server/mcp/tools/notify-all.ts
@@ -1,0 +1,16 @@
+import { defineMcpTool } from '../../../../../../src/runtime/server/types'
+import { useMcpLogger } from '../../../../../../src/runtime/server/mcp/logger'
+
+export default defineMcpTool({
+  name: 'notify_all',
+  description: 'Send one notification per level (debug, info, warning, error)',
+  inputSchema: {},
+  handler: async () => {
+    const log = useMcpLogger('notify-all')
+    await log.notify.debug({ msg: 'd' })
+    await log.notify.info({ msg: 'i' })
+    await log.notify.warning({ msg: 'w' })
+    await log.notify.error({ msg: 'e' })
+    return { content: [{ type: 'text', text: 'sent' }] }
+  },
+})

--- a/packages/nuxt-mcp-toolkit/test/fixtures/logger/server/mcp/tools/notify-named.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/logger/server/mcp/tools/notify-named.ts
@@ -1,0 +1,14 @@
+import { defineMcpTool } from '../../../../../../src/runtime/server/types'
+import { useMcpLogger } from '../../../../../../src/runtime/server/mcp/logger'
+
+export default defineMcpTool({
+  name: 'notify_named',
+  description: 'Send a single info notification using the prefix override',
+  inputSchema: {},
+  handler: async () => {
+    const log = useMcpLogger('default-prefix')
+    await log.notify.info({ msg: 'first' })
+    await log.notify.info({ msg: 'override' }, 'override-prefix')
+    return { content: [{ type: 'text', text: 'sent' }] }
+  },
+})

--- a/packages/nuxt-mcp-toolkit/test/fixtures/logger/server/mcp/tools/wide-event.ts
+++ b/packages/nuxt-mcp-toolkit/test/fixtures/logger/server/mcp/tools/wide-event.ts
@@ -1,0 +1,27 @@
+import { defineMcpTool } from '../../../../../../src/runtime/server/types'
+import { useMcpLogger } from '../../../../../../src/runtime/server/mcp/logger'
+
+export default defineMcpTool({
+  name: 'wide_event',
+  description: 'Populate the evlog wide event via set/event and return its context',
+  inputSchema: {},
+  handler: async () => {
+    const log = useMcpLogger()
+    log.set({ user: { id: 'user-42' } })
+    log.set({ feature: 'logger-test' })
+    log.event('charge_started', { amount: 1000 })
+
+    const ctx = log.evlog.getContext() as Record<string, unknown>
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            user: ctx.user,
+            feature: ctx.feature,
+          }),
+        },
+      ],
+    }
+  },
+})

--- a/packages/nuxt-mcp-toolkit/test/logger-disabled.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/logger-disabled.test.ts
@@ -1,0 +1,68 @@
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect, afterAll } from 'vitest'
+import { setup, url } from '@nuxt/test-utils/e2e'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
+
+interface CapturedNotification {
+  level: string
+  data: unknown
+  logger?: string
+}
+
+function createMcpUrl(path = '/mcp') {
+  const baseUrl = url('/')
+  const baseUrlObj = new URL(baseUrl)
+  const origin = `${baseUrlObj.protocol}//${baseUrlObj.host}`
+  return new URL(path, origin)
+}
+
+async function waitForNotifications(notifications: CapturedNotification[], expected: number, timeoutMs = 1500) {
+  const start = Date.now()
+  while (notifications.length < expected) {
+    if (Date.now() - start > timeoutMs) break
+    await new Promise(resolve => setTimeout(resolve, 25))
+  }
+}
+
+describe('useMcpLogger with mcp.logging: false', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/logger-disabled', import.meta.url)),
+  })
+
+  const opened: Client[] = []
+
+  afterAll(async () => {
+    for (const c of opened) {
+      try {
+        await c.close()
+      }
+      catch {
+        // Ignore close errors — the test process is exiting anyway.
+      }
+    }
+  })
+
+  it('keeps notify working but throws on set()/event() when observability is disabled', async () => {
+    const notifications: CapturedNotification[] = []
+    const client = new Client({ name: 'logger-disabled-test', version: '1.0.0' })
+    client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+      notifications.push(notification.params as CapturedNotification)
+    })
+    await client.connect(new StreamableHTTPClientTransport(createMcpUrl()))
+    opened.push(client)
+
+    const result = await client.callTool({ name: 'notify_only', arguments: {} })
+    await waitForNotifications(notifications, 1)
+
+    expect(notifications).toHaveLength(1)
+    expect(notifications[0]!.level).toBe('info')
+    expect(notifications[0]!.logger).toBe('disabled-fixture')
+
+    const content = result.content as Array<{ type: string, text?: string }>
+    const payload = JSON.parse(content[0]!.text!)
+    expect(payload.setError).toBe('McpObservabilityNotEnabledError')
+    expect(payload.eventError).toBe('McpObservabilityNotEnabledError')
+  })
+})

--- a/packages/nuxt-mcp-toolkit/test/logger.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/logger.test.ts
@@ -1,0 +1,109 @@
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect, afterAll } from 'vitest'
+import { setup, url } from '@nuxt/test-utils/e2e'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
+
+function createMcpUrl(path = '/mcp') {
+  const baseUrl = url('/')
+  const baseUrlObj = new URL(baseUrl)
+  const origin = `${baseUrlObj.protocol}//${baseUrlObj.host}`
+  return new URL(path, origin)
+}
+
+interface CapturedNotification {
+  level: string
+  data: unknown
+  logger?: string
+}
+
+async function createLoggingClient(): Promise<{
+  client: Client
+  notifications: CapturedNotification[]
+}> {
+  const notifications: CapturedNotification[] = []
+  const client = new Client({ name: 'logger-test-client', version: '1.0.0' })
+
+  client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+    notifications.push(notification.params as CapturedNotification)
+  })
+
+  await client.connect(new StreamableHTTPClientTransport(createMcpUrl()))
+  return { client, notifications }
+}
+
+async function waitForNotifications(notifications: CapturedNotification[], expected: number, timeoutMs = 1500) {
+  const start = Date.now()
+  while (notifications.length < expected) {
+    if (Date.now() - start > timeoutMs) break
+    await new Promise(resolve => setTimeout(resolve, 25))
+  }
+}
+
+describe('useMcpLogger', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/logger', import.meta.url)),
+  })
+
+  const opened: Client[] = []
+
+  afterAll(async () => {
+    for (const c of opened) {
+      try {
+        await c.close()
+      }
+      catch {
+        // Ignore close errors — the test process is exiting anyway.
+      }
+    }
+  })
+
+  it('streams every notify level to the client by default', async () => {
+    const { client, notifications } = await createLoggingClient()
+    opened.push(client)
+
+    await client.callTool({ name: 'notify_all', arguments: {} })
+    await waitForNotifications(notifications, 4)
+
+    const levels = notifications.map(n => n.level)
+    expect(levels).toEqual(['debug', 'info', 'warning', 'error'])
+
+    const loggers = new Set(notifications.map(n => n.logger))
+    expect(loggers).toEqual(new Set(['notify-all']))
+  })
+
+  it('honors the logging/setLevel filter set by the client', async () => {
+    const { client, notifications } = await createLoggingClient()
+    opened.push(client)
+
+    await client.setLoggingLevel('warning')
+    await client.callTool({ name: 'notify_all', arguments: {} })
+    await waitForNotifications(notifications, 2, 1000)
+
+    const levels = notifications.map(n => n.level)
+    expect(levels).toEqual(['warning', 'error'])
+  })
+
+  it('lets the per-call logger override take precedence over the prefix', async () => {
+    const { client, notifications } = await createLoggingClient()
+    opened.push(client)
+
+    await client.callTool({ name: 'notify_named', arguments: {} })
+    await waitForNotifications(notifications, 2)
+
+    expect(notifications.map(n => n.logger)).toEqual(['default-prefix', 'override-prefix'])
+  })
+
+  it('set() and event() populate the request-scoped evlog context', async () => {
+    const { client } = await createLoggingClient()
+    opened.push(client)
+
+    const result = await client.callTool({ name: 'wide_event', arguments: {} })
+    const content = result.content as Array<{ type: string, text?: string }>
+    const ctx = JSON.parse(content[0]!.text!)
+
+    expect(ctx.user).toEqual({ id: 'user-42' })
+    expect(ctx.feature).toBe('logger-test')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,9 +170,6 @@ importers:
       agents:
         specifier: '>=0.11.4'
         version: 0.11.4(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260329.1)(ai@6.0.168(zod@4.3.6))(react@19.2.4)(rolldown@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(zod@4.3.6)
-      evlog:
-        specifier: ^2.13.0
-        version: 2.13.0(@nuxt/kit@4.4.2(magicast@0.5.2))(ai@6.0.168(zod@4.3.6))(better-auth@1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0))(vue@3.5.32(typescript@6.0.3)))(express@5.2.1)(fastify@5.8.4)(h3@1.15.11)(hono@4.12.9)(ofetch@1.5.1)(react@19.2.4)
       h3:
         specifier: '>=1.15.11'
         version: 1.15.11
@@ -207,6 +204,9 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
+      evlog:
+        specifier: ^2.13.0
+        version: 2.13.0(@nuxt/kit@4.4.2(magicast@0.5.2))(ai@6.0.168(zod@4.3.6))(better-auth@1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0))(vue@3.5.32(typescript@6.0.3)))(express@5.2.1)(fastify@5.8.4)(h3@1.15.11)(hono@4.12.9)(ofetch@1.5.1)(react@19.2.4)
       nuxt:
         specifier: ^4.4.2
         version: 4.4.2(f0937b82c79e2c2f1c4d910a44ec686b)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,7 +126,7 @@ importers:
         version: 6.0.168(zod@4.3.6)
       better-auth:
         specifier: ^1.6.5
-        version: 1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(vue@3.5.32(typescript@6.0.3))
+        version: 1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0))(vue@3.5.32(typescript@6.0.3))
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14)
@@ -170,6 +170,9 @@ importers:
       agents:
         specifier: '>=0.11.4'
         version: 0.11.4(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260329.1)(ai@6.0.168(zod@4.3.6))(react@19.2.4)(rolldown@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(zod@4.3.6)
+      evlog:
+        specifier: ^2.13.0
+        version: 2.13.0(@nuxt/kit@4.4.2(magicast@0.5.2))(ai@6.0.168(zod@4.3.6))(better-auth@1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0))(vue@3.5.32(typescript@6.0.3)))(express@5.2.1)(fastify@5.8.4)(h3@1.15.11)(hono@4.12.9)(ofetch@1.5.1)(react@19.2.4)
       h3:
         specifier: '>=1.15.11'
         version: 1.15.11
@@ -9882,7 +9885,7 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.0
-      better-auth: 1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(vue@3.5.32(typescript@6.0.3))
+      better-auth: 1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0))(vue@3.5.32(typescript@6.0.3))
       zod: 4.3.6
 
   '@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)':
@@ -14434,7 +14437,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.12: {}
 
-  better-auth@1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(vue@3.5.32(typescript@6.0.3)):
+  better-auth@1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0))(vue@3.5.32(typescript@6.0.3)):
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))
@@ -14457,6 +14460,7 @@ snapshots:
       better-sqlite3: 12.9.0
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14)
+      react: 19.2.4
       vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vue: 3.5.32(typescript@6.0.3)
     transitivePeerDependencies:
@@ -15744,11 +15748,23 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
+  evlog@2.13.0(@nuxt/kit@4.4.2(magicast@0.5.2))(ai@6.0.168(zod@4.3.6))(better-auth@1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0))(vue@3.5.32(typescript@6.0.3)))(express@5.2.1)(fastify@5.8.4)(h3@1.15.11)(hono@4.12.9)(ofetch@1.5.1)(react@19.2.4):
+    optionalDependencies:
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      ai: 6.0.168(zod@4.3.6)
+      better-auth: 1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0))(vue@3.5.32(typescript@6.0.3))
+      express: 5.2.1
+      fastify: 5.8.4
+      h3: 1.15.11
+      hono: 4.12.9
+      ofetch: 1.5.1
+      react: 19.2.4
+
   evlog@2.13.0(@nuxt/kit@4.4.2(magicast@0.5.2))(ai@6.0.168(zod@4.3.6))(better-auth@1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(vue@3.5.32(typescript@6.0.3)))(express@5.2.1)(fastify@5.8.4)(h3@1.15.11)(hono@4.12.9)(ofetch@1.5.1)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       ai: 6.0.168(zod@4.3.6)
-      better-auth: 1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(vue@3.5.32(typescript@6.0.3))
+      better-auth: 1.6.5(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@electric-sql/pglite@0.4.4)(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(kysely@0.28.14))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0))(vue@3.5.32(typescript@6.0.3))
       express: 5.2.1
       fastify: 5.8.4
       h3: 1.15.11


### PR DESCRIPTION
## Summary

Adds `useMcpLogger()` and first-class observability via [evlog](https://evlog.dev), shipped as a direct dependency of the toolkit.

The composable has a deliberately split API so it's always obvious what reaches the user vs. your server logs:

```typescript
const log = useMcpLogger('billing')

// → MCP CLIENT (Inspector / Cursor / Claude — notifications/message)
await log.notify.info({ msg: 'starting charge', amount })

// → SERVER (dev terminal + drains, request-scoped wide event)
log.set({ user: { id: userId } })
log.event('charge_started', { amount })
```

### Native MCP wide-event tagging

Every MCP request runs inside an evlog wide event automatically tagged from the JSON-RPC payload — no user code required:

| Field | Description |
|---|---|
| `mcp.transport` | `streamable-http` / `cloudflare-do` |
| `mcp.route` | The configured MCP endpoint path |
| `mcp.session_id` | From the `mcp-session-id` header |
| `mcp.method` | `tools/call`, `tools/list`, `initialize`, … |
| `mcp.request_id` | The JSON-RPC id |
| `mcp.tool` / `mcp.resource` / `mcp.prompt` | Filled per `tools/call` / `resources/read` / `prompts/get` |

Batched JSON-RPC payloads expose plural arrays (\`mcp.methods\`, \`mcp.tools\`, …). Body parsing piggybacks on h3's cached \`readBody\`, so the SDK transport still consumes the stream correctly.

### Why this lives in the toolkit

- The toolkit declares the \`logging\` server capability and respects the client's \`logging/setLevel\` per session.
- evlog is wired through Nitro automatically. Drains (Axiom, OTLP, HyperDX, Sentry, Datadog, …), sampling, and redaction are configured via \`mcp.logging\` in \`nuxt.config.ts\`. Pass \`logging: false\` to opt out — the \`notify\` channel keeps working.
- We wrap \`evlog/nitro\` so it no longer forces \`noExternals: true\` globally; we inline only \`evlog\` and \`evlog/nitro\`. This restores compatibility with \`@nuxthub/core\` (which pulls \`drizzle-kit\` with native CLI bindings) and other modules that ship CLI binaries.

### Side-effect on the handler

The MCP route handler now tags the active wide event from inside the request (instead of via a separate Nitro plugin). This guarantees evlog has finished initialising \`event.context.log\` before we touch it, fixing a previous race that caused silent \"Logger not initialized\" warnings.

### Playground

- New \`observability_demo\` tool that pushes a couple of \`notify\` lines and tags the wide event.
- New \`/mcp-test\` console with a notifications panel and a \`logging/setLevel\` selector.

### Docs

- New \`advanced/logging\` page covering both channels, the auto-tagged \`mcp.*\` fields, and drain configuration.
- Logger section in the manage-mcp skill.
- \`charge_card\` example in the tools reference now uses \`log.notify.info\`.

### Note about \`.gitignore\`

Tightened the \`*.log*\` rule to \`*.log\` + \`*.log.*\` so that \`apps/docs/content/3.advanced/10.logging.md\` (the new docs page) isn't accidentally swallowed.