### PR TITLE
chore: upgrade pnpm to v11 and add minimumReleaseAge

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.4
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.4
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -33,8 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.4
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -51,8 +47,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.4
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -69,8 +63,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.4
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -91,8 +83,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10.33.4
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-shamefully-hoist=true
-strict-peer-dependencies=false

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "author": "Hugo Richard <hugo.richard@vercel.com>",
   "license": "MIT",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.3",
   "scripts": {
     "dev": "turbo run dev --filter=@nuxtjs/mcp-toolkit-playground",
     "dev:starter": "turbo run dev --filter=@nuxtjs/mcp-toolkit-starter",
@@ -42,10 +42,5 @@
   "workspaces": [
     "apps/*",
     "packages/*"
-  ],
-  "pnpm": {
-    "overrides": {
-      "@nuxtjs/mcp-toolkit": "workspace:*"
-    }
-  }
+  ]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,3 +16,16 @@ allowBuilds:
 
 overrides:
   '@nuxtjs/mcp-toolkit': workspace:*
+
+minimumReleaseAge: 2880
+
+minimumReleaseAgeExclude:
+  # Nuxt
+  - '@nuxt/*'
+  - '@nuxtjs/*'
+  - 'nuxt'
+  - 'nuxt-*'
+  # Vercel
+  - '@vercel/*'
+  - '@ai-sdk/*'
+  - 'ai'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,8 @@ allowBuilds:
   esbuild: false
   unrs-resolver: false
   vue-demi: false
+  cbor-extract: false
+  core-js-pure: false
   better-sqlite3: true
   isolated-vm: true
   sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,13 +2,17 @@ packages:
   - apps/*
   - packages/*
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-  - unrs-resolver
-  - vue-demi
+shamefullyHoist: true
+strictPeerDependencies: false
 
-onlyBuiltDependencies:
-  - better-sqlite3
-  - isolated-vm
-  - sharp
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  unrs-resolver: false
+  vue-demi: false
+  better-sqlite3: true
+  isolated-vm: true
+  sharp: true
+
+overrides:
+  '@nuxtjs/mcp-toolkit': workspace:*


### PR DESCRIPTION
## Summary

Two related changes to harden the supply chain and modernize the package manager setup.

### 1. Upgrade pnpm to v11

- Bump `packageManager` to `pnpm@11.1.3`
- Drop pinned `version: 10.33.4` from `pnpm/action-setup` workflows — the action now reads `packageManager` from `package.json` (single source of truth)
- Migrate `onlyBuiltDependencies` + `ignoredBuiltDependencies` → unified `allowBuilds` map (required in v11)
- Move `overrides` from `package.json` → `pnpm-workspace.yaml` (the `pnpm` field in `package.json` is no longer recognized in v11)
- Move `shamefullyHoist`, `strictPeerDependencies` from `.npmrc` → `pnpm-workspace.yaml` (in v11, `.npmrc` only holds auth/registry)
- Delete `.npmrc` (now empty)

### 2. Add `minimumReleaseAge` to harden supply chain

Sets a 2-day minimum age (2880 minutes) before any newly published dependency can resolve. Mitigates compromised-package attacks where a malicious version is pushed and pulled into installs within hours.

Trusted-source allowlist exempts the Nuxt and Vercel ecosystems:
- `@nuxt/*`, `@nuxtjs/*`, `nuxt`, `nuxt-*`
- `@vercel/*`, `@ai-sdk/*`, `ai`

## Test plan
- [ ] `pnpm install` resolves cleanly with v11 (lockfile already verified via `--lockfile-only`, 1975 entries pass supply-chain policies)
- [ ] CI passes: ci.yml, autofix.yml
- [ ] Module dev workflow still works (`pnpm dev:prepare`)