### PR TITLE
fix: strip TypeScript from emitted handler code

### DIFF
--- a/packages/nuxt-mcp-toolkit/src/setup/mcp-apps/emit.ts
+++ b/packages/nuxt-mcp-toolkit/src/setup/mcp-apps/emit.ts
@@ -2,6 +2,7 @@ import { addServerTemplate } from '@nuxt/kit'
 import type { Resolver } from '@nuxt/kit'
 import type { DiscoveredApp } from './discover'
 import type { ParsedSfcApp } from './parse-sfc'
+import { stripTypeScriptFromMacroArg } from './strip-typescript'
 
 export interface ResolvedAttribution {
   /** Final `attachTo` value (explicit override > sub-folder > `'apps'`). */
@@ -72,6 +73,3 @@ export default _createAppResource(_app, { name: ${JSON.stringify(app.name)}, htm
   return { toolFile, resourceFile }
 }
 
-function stripTypeScriptFromMacroArg(argText: string): string {
-  return argText.replace(/\):[^=\n]*=>/g, ') =>')
-}

--- a/packages/nuxt-mcp-toolkit/src/setup/mcp-apps/emit.ts
+++ b/packages/nuxt-mcp-toolkit/src/setup/mcp-apps/emit.ts
@@ -72,4 +72,3 @@ export default _createAppResource(_app, { name: ${JSON.stringify(app.name)}, htm
 
   return { toolFile, resourceFile }
 }
-

--- a/packages/nuxt-mcp-toolkit/src/setup/mcp-apps/strip-typescript.ts
+++ b/packages/nuxt-mcp-toolkit/src/setup/mcp-apps/strip-typescript.ts
@@ -1,0 +1,132 @@
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+
+const MCP_APP_ARG_PREFIX = 'const __mcpAppArg = '
+
+function tryLoadEsbuild(): typeof import('esbuild') | null {
+  try {
+    return require('esbuild') as typeof import('esbuild')
+  }
+  catch {
+    return null
+  }
+}
+
+function extractAssignedExpression(code: string): string {
+  const trimmed = code.trim().replace(/;\s*$/, '')
+  if (trimmed.startsWith(MCP_APP_ARG_PREFIX)) {
+    return trimmed.slice(MCP_APP_ARG_PREFIX.length)
+  }
+  return trimmed
+}
+
+/**
+ * Remove TypeScript-only syntax from a `defineMcpApp({ ... })` argument object
+ * before it is embedded in `.mjs` Nitro virtual modules (Rollup parses those as JS).
+ */
+export function stripTypeScriptFromMacroArg(argText: string): string {
+  const esbuild = tryLoadEsbuild()
+  if (esbuild) {
+    try {
+      const result = esbuild.transformSync(`${MCP_APP_ARG_PREFIX}${argText}`, {
+        loader: 'ts',
+        target: 'esnext',
+      })
+      return extractAssignedExpression(result.code)
+    }
+    catch {
+      // Fall through to the heuristic stripper below.
+    }
+  }
+
+  return stripTypeScriptFromMacroArgHeuristic(argText)
+}
+
+/** Regex/balanced-bracket fallback when esbuild is unavailable. */
+function stripTypeScriptFromMacroArgHeuristic(argText: string): string {
+  let out = stripCallTypeArguments(argText)
+  out = out.replace(/\):[^=\n]*=>/g, ') =>')
+  return out
+}
+
+/**
+ * Strip generic call-site type arguments, e.g.
+ * `$fetch<T>(url)` → `$fetch(url)`.
+ *
+ * Uses the `>`-then-`(` heuristic to avoid eating comparison operators (`a < b`).
+ */
+function stripCallTypeArguments(source: string): string {
+  let out = ''
+  let i = 0
+
+  while (i < source.length) {
+    if (source[i] === '<' && isGenericTypeArgumentStart(source, i)) {
+      const end = skipBalancedGenerics(source, i)
+      if (end !== -1 && isGenericTypeArgumentEnd(source, end)) {
+        i = end + 1
+        continue
+      }
+    }
+    out += source[i]
+    i++
+  }
+
+  return out
+}
+
+function isGenericTypeArgumentStart(source: string, index: number): boolean {
+  let j = index - 1
+  while (j >= 0 && /\s/.test(source[j]!)) j--
+  if (j < 0) return false
+  return /[\w)\]>]$/.test(source[j]!)
+}
+
+function isGenericTypeArgumentEnd(source: string, closeIndex: number): boolean {
+  let j = closeIndex + 1
+  while (j < source.length && /\s/.test(source[j]!)) j++
+  const next = source[j]
+  return next === '(' || next === '.' || next === '<' || next === '['
+}
+
+function skipBalancedGenerics(source: string, openIndex: number): number {
+  let depth = 0
+  let str: string | null = null
+
+  for (let i = openIndex; i < source.length; i++) {
+    const c = source[i]
+    const next = source[i + 1]
+
+    if (str) {
+      if (c === '\\') {
+        i++
+        continue
+      }
+      if (c === str) str = null
+      continue
+    }
+
+    if (c === '/' && next === '/') {
+      const eol = source.indexOf('\n', i)
+      i = eol === -1 ? source.length - 1 : eol
+      continue
+    }
+    if (c === '/' && next === '*') {
+      const close = source.indexOf('*/', i + 2)
+      i = close === -1 ? source.length - 1 : close + 1
+      continue
+    }
+    if (c === '"' || c === '\'' || c === '`') {
+      str = c
+      continue
+    }
+
+    if (c === '<') depth++
+    else if (c === '>') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+
+  return -1
+}

--- a/packages/nuxt-mcp-toolkit/test/strip-typescript.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/strip-typescript.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { stripTypeScriptFromMacroArg } from '../src/setup/mcp-apps/strip-typescript'
+
+describe('stripTypeScriptFromMacroArg', () => {
+  it('strips generic type arguments on $fetch calls (issue #279)', () => {
+    const input = `{
+  handler: async ({ base }) => {
+    const swatches = await $fetch<{ name: string, hex: string }[]>('/api/palette', {
+      query: { base },
+    })
+    return { structuredContent: { swatches } }
+  },
+}`
+
+    const out = stripTypeScriptFromMacroArg(input)
+
+    expect(out).not.toMatch(/\$fetch</)
+    expect(out).toContain('$fetch("/api/palette"')
+    expect(out).toContain('query: { base }')
+  })
+
+  it('strips arrow-function return type annotations', () => {
+    const input = `{
+  handler: async ({ base }): Promise<{ structuredContent: PalettePayload }> => ({
+    structuredContent: await $fetch('/api/palette', { query: { base } }),
+  }),
+}`
+
+    const out = stripTypeScriptFromMacroArg(input)
+
+    expect(out).not.toMatch(/\): Promise</)
+    expect(out).toContain('handler: async ({ base }) =>')
+  })
+
+  it('strips parameter type annotations', () => {
+    const input = `{ handler: async (x: string, y: number) => x + y }`
+
+    expect(stripTypeScriptFromMacroArg(input)).toContain('async (x, y) => x + y')
+  })
+
+  it('preserves comparison operators', () => {
+    const input = `{ handler: async () => a < b && c > d }`
+
+    expect(stripTypeScriptFromMacroArg(input)).toContain('a < b && c > d')
+  })
+})


### PR DESCRIPTION
MCP App macro args are inlined into `.mjs` virtual modules that Rollup parses as JavaScript, so TS syntax like `$fetch<T>()` caused build failures. Transpile macro args with esbuild before emission and add a heuristic fallback.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- docs (the documentation)
- playground (the playground)
- module (the module)
- deps (dependencies of the project)
-->

### 🔗 Linked issue

Resolves #279 

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
