### PR TITLE
feat: expose initialData from useMcpApp()

### DIFF
--- a/.changeset/use-mcp-app-initial-data.md
+++ b/.changeset/use-mcp-app-initial-data.md
@@ -1,0 +1,5 @@
+---
+"@nuxtjs/mcp-toolkit": patch
+---
+
+Expose `initialData` from `useMcpApp()` as an immutable snapshot of the handler's initial `structuredContent`, separate from `data` which continues to refresh on `callTool` and host `tool-result` pushes. Closes #280.

--- a/apps/docs/content/6.apps/2.use-mcp-app.md
+++ b/apps/docs/content/6.apps/2.use-mcp-app.md
@@ -14,6 +14,7 @@ The single client-side composable, **auto-imported into every MCP App SFC**. It 
 
 ```ts
 const {
+  initialData,  // Ref<T | null>          — snapshot of the handler payload at mount, never updated
   data,         // Ref<T | null>          — hydrated from structuredContent, refreshed by callTool
   loading,      // Ref<boolean>           — true until first payload arrives
   error,        // Ref<Error | null>      — bridge / transport / payload errors
@@ -27,9 +28,22 @@ const {
 
 Pass your payload type as the generic to get full inference downstream.
 
-### `data` & `loading`
+### `initialData` & `data`
 
-`data` is **already populated on first render** when the handler returns `structuredContent`. `loading` starts as `true` and becomes `false` after the first payload arrives. Use `pending` for in-flight `callTool()` refreshes:
+`initialData` is a **frozen snapshot** of the handler's `structuredContent` inlined at build time (or `window.openai.toolOutput` on ChatGPT). It never changes — use it for bootstrap values such as IDs or query params that later `callTool` results might overwrite in `data`.
+
+`data` is **already populated on first render** when the handler returns `structuredContent`, then refreshed by `callTool` or host `tool-result` pushes. `loading` starts as `true` and becomes `false` after the first payload arrives. Use `pending` for in-flight `callTool()` refreshes:
+
+```vue
+<script setup lang="ts">
+const { initialData, data, callTool } = useMcpApp<{ listId: string }>()
+
+async function refresh() {
+  const result = await callTool('list_todos', { listId: initialData.value!.listId })
+  // `data` now holds the latest tool result; `initialData` still has `{ listId }`
+}
+</script>
+```
 
 ```vue
 <template>

--- a/apps/docs/content/6.apps/5.patterns-reference.md
+++ b/apps/docs/content/6.apps/5.patterns-reference.md
@@ -72,7 +72,7 @@ Need rich components? Build a small co-located design system in your apps direct
 | API | Where | Purpose |
 |---|---|---|
 | `defineMcpApp()` | `<script setup>` | Declare the tool, schema, handler, CSP. Stripped from the browser bundle. |
-| `useMcpApp<T>()` | SFC body | Reactive `data` / `loading` / `hostContext` + `callTool`, `sendPrompt`, `openLink`. |
+| `useMcpApp<T>()` | SFC body | Reactive `initialData` / `data` / `loading` / `hostContext` + `callTool`, `sendPrompt`, `openLink`. |
 | `csp.resourceDomains` | `defineMcpApp` | Allow-list image / font / style origins. |
 | `csp.connectDomains` | `defineMcpApp` | Allow-list `fetch` / `XHR` / `WebSocket` origins. |
 | `_meta` | `defineMcpApp` | Extra `_meta` fields surfaced to the host alongside `ui.resourceUri` and `ui.csp`. |

--- a/apps/docs/skills/manage-mcp/references/apps.md
+++ b/apps/docs/skills/manage-mcp/references/apps.md
@@ -127,6 +127,7 @@ Auto-imported into every MCP App SFC. Returns the iframe ↔ host bridge:
 
 ```typescript
 const {
+  initialData,  // Ref<T | null>            — snapshot of handler payload at mount, never updated
   data,         // Ref<T | null>            — hydrated from structuredContent, refreshed by callTool
   loading,      // Ref<boolean>             — true until first payload arrives
   error,        // Ref<Error | null>        — bridge / transport / payload errors
@@ -137,6 +138,8 @@ const {
   openLink,     // (url: string) => void
 } = useMcpApp<MyPayload>()
 ```
+
+Use `initialData` for bootstrap values (IDs, query params) that must survive later `callTool` refreshes overwriting `data`.
 
 ### Adapt to host theme & layout
 

--- a/packages/nuxt-mcp-toolkit/src/runtime/app/use-mcp-app-data.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/app/use-mcp-app-data.ts
@@ -2,6 +2,8 @@ import { getCurrentScope, onScopeDispose, ref, type Ref } from 'vue'
 import { useHostBridge, type HostContext } from './host-bridge'
 
 export interface UseMcpAppDataReturn<T> {
+  /** Snapshot of the inline data-script (or `window.openai.toolOutput`) at mount — never updated. */
+  initialData: Ref<T | null>
   /** Hydrated from the inline data-script, then refreshed via host `tool-result` pushes. */
   data: Ref<T | null>
   /** One-way latch: `true` until the first payload arrives, `false` forever after. */
@@ -20,6 +22,9 @@ export interface UseMcpAppDataReturn<T> {
 export function useMcpAppData<T = unknown>(): UseMcpAppDataReturn<T> {
   const bridge = useHostBridge()
 
+  const initialData = ref<T | null>(
+    bridge.initialData !== undefined ? (bridge.initialData as T) : null,
+  ) as Ref<T | null>
   const data = ref<T | null>(null) as Ref<T | null>
   const loading = ref(true)
 
@@ -35,6 +40,7 @@ export function useMcpAppData<T = unknown>(): UseMcpAppDataReturn<T> {
   if (getCurrentScope()) onScopeDispose(unsubscribe)
 
   return {
+    initialData,
     data,
     loading,
     error: bridge.error,

--- a/packages/nuxt-mcp-toolkit/src/runtime/app/use-mcp-app.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/app/use-mcp-app.ts
@@ -8,6 +8,8 @@ import { useExternalLink } from './use-external-link'
 export type { HostContext } from './host-bridge'
 
 export interface UseMcpAppReturn<T = unknown> {
+  /** Snapshot of the handler's initial `structuredContent` at mount — never updated. */
+  initialData: Ref<T | null>
   /** Hydrated from the inline data-script, then refreshed via `tool-result` and `callTool`. */
   data: Ref<T | null>
   /** Last error from the host, the transport, or a malformed payload. */
@@ -33,7 +35,7 @@ export interface UseMcpAppReturn<T = unknown> {
  * Auto-imported into `app/mcp/*.vue` SFCs — usually no explicit import needed.
  */
 export function useMcpApp<T = unknown>(): UseMcpAppReturn<T> {
-  const { data, loading, error, hostContext } = useMcpAppData<T>()
+  const { initialData, data, loading, error, hostContext } = useMcpAppData<T>()
   const sendPrompt = useFollowUp()
   const openLink = useExternalLink()
   const tool = useToolCall<T>()
@@ -46,6 +48,7 @@ export function useMcpApp<T = unknown>(): UseMcpAppReturn<T> {
   }
 
   return {
+    initialData,
     data,
     error,
     loading,

--- a/packages/nuxt-mcp-toolkit/test/apps-handshake.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/apps-handshake.test.ts
@@ -181,12 +181,14 @@ describe('useMcpApp (host bridge)', () => {
       api = useMcpApp<{ items?: number, hydrated?: boolean }>()
     })
 
+    expect(api?.initialData.value).toEqual({ hydrated: true })
     expect(api?.data.value).toEqual({ hydrated: true })
 
     const out = await api!.callTool('refilter', { type: 'Villa' })
     expect(calls[0]).toEqual(['callTool', { name: 'refilter', args: { type: 'Villa' } }])
     expect(out).toEqual({ items: 3 })
     expect(api?.data.value).toEqual({ items: 3 })
+    expect(api?.initialData.value).toEqual({ hydrated: true })
     expect(win.posted.find(p => p.method === 'tools/call')).toBeUndefined()
 
     api!.sendPrompt('hello')
@@ -197,6 +199,47 @@ describe('useMcpApp (host bridge)', () => {
     expect(calls[2]).toEqual(['openExternal', { href: 'https://example.com/path' }])
     expect(win.posted.find(p => p.method === 'ui/open-link')).toBeUndefined()
 
+    scope.stop()
+  })
+
+  it('keeps `initialData` unchanged when `data` is refreshed by callTool or tool-result', async () => {
+    ;(globalThis as { document: { getElementById: (id: string) => { textContent: string } | null, readyState: string } }).document = {
+      getElementById: (id: string) =>
+        id === '__mcp_app_data__' ? { textContent: JSON.stringify({ listId: 'abc-123' }) } : null,
+      readyState: 'complete',
+    }
+
+    const { useMcpApp } = await import('../src/runtime/app/use-mcp-app')
+    const scope = effectScope()
+    let api: ReturnType<typeof useMcpApp<{ listId: string, total?: number }>> | undefined
+    scope.run(() => {
+      api = useMcpApp<{ listId: string, total?: number }>()
+    })
+
+    expect(api?.initialData.value).toEqual({ listId: 'abc-123' })
+    expect(api?.data.value).toEqual({ listId: 'abc-123' })
+
+    dispatch({
+      jsonrpc: '2.0',
+      method: 'ui/notifications/tool-result',
+      params: { structuredContent: { total: 2 } },
+    })
+    expect(api?.data.value).toEqual({ total: 2 })
+    expect(api?.initialData.value).toEqual({ listId: 'abc-123' })
+
+    const callPromise = api!.callTool('list_todos', { listId: 'abc-123' })
+    await flush()
+    const out = win.posted.find(p => p.method === 'tools/call')
+    dispatch({
+      jsonrpc: '2.0',
+      id: out!.id,
+      // @ts-expect-error: result is JSON-RPC, not in the outgoing Posted shape
+      result: { structuredContent: { total: 5 } },
+    })
+    await callPromise
+
+    expect(api?.data.value).toEqual({ total: 5 })
+    expect(api?.initialData.value).toEqual({ listId: 'abc-123' })
     scope.stop()
   })
 


### PR DESCRIPTION
## Summary

- Expose `initialData` from `useMcpApp()` as an immutable snapshot of the handler's initial `structuredContent`, separate from `data` which continues to refresh on `callTool` and host `tool-result` pushes.
- Add regression tests covering inline script hydration, ChatGPT `toolOutput`, and post-refresh immutability.
- Document the new API in the MCP Apps guide and manage-mcp skill reference.

Closes #280.

## Test plan

- [x] `pnpm test apps-handshake.test.ts` — 11 tests pass
- [ ] Open an MCP App in the playground and confirm `initialData` stays stable after `callTool` refreshes `data`