### PR TITLE
fix: keep changeset publish away from the alpha package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,19 @@ jobs:
       - name: Audit published surface
         run: pnpm run lint:package
 
+      # `changeset publish` skips private packages and nothing else — `ignore`
+      # applies to versioning only. So an unreleased version sitting on main
+      # makes the stable release workflow try to publish the alpha and fail.
+      - name: The alpha version on main must already be on npm
+        run: |
+          version=$(node -p "require('./packages/nitro-mcp-toolkit/package.json').version")
+          if npm view "nitro-mcp-toolkit@$version" version > /dev/null 2>&1; then
+            echo "nitro-mcp-toolkit@$version is on npm"
+          else
+            echo "::error::nitro-mcp-toolkit@$version is not published. Do not bump this version by hand — release it from the release-alpha workflow, which publishes before it commits the bump."
+            exit 1
+          fi
+
   publish:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -7,6 +7,15 @@ name: release-alpha
 
 on:
   workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump (preminor for the first alpha of a new minor)'
+        type: choice
+        options:
+          - prerelease
+          - preminor
+          - premajor
+        default: prerelease
 
 concurrency: ${{ github.workflow }}
 
@@ -43,6 +52,7 @@ jobs:
       - name: Publish
         run: pnpm run release:alpha
         env:
+          BUMP: ${{ inputs.bump }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -4,6 +4,10 @@ name: release-alpha
 # for the whole monorepo at once. `nitro-mcp-toolkit` is being written wave by
 # wave while `@nuxtjs/mcp-toolkit` keeps shipping stable, so it releases from
 # here instead, always under the `alpha` dist-tag.
+#
+# It authenticates with NPM_TOKEN_ALPHA rather than the NPM_TOKEN the stable
+# release uses: the package is owned by a personal npm account, so the Nuxt org
+# token gets a 404 on it. Scope that token to this one package.
 
 on:
   workflow_dispatch:
@@ -49,11 +53,22 @@ jobs:
           pnpm --filter nitro-mcp-toolkit test
           pnpm --filter nitro-mcp-toolkit lint:package
 
+      # Without this the failure arrives as a bare npm 404, which reads like the
+      # package does not exist rather than like a missing credential.
+      - name: Check the release token
+        env:
+          TOKEN: ${{ secrets.NPM_TOKEN_ALPHA }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::NPM_TOKEN_ALPHA is not set. nitro-mcp-toolkit is owned by a personal npm account, so the org's NPM_TOKEN cannot publish it. Add a granular token scoped to that one package as a repository secret."
+            exit 1
+          fi
+
       - name: Publish
         run: pnpm run release:alpha
         env:
           BUMP: ${{ inputs.bump }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ALPHA }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Record the released version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,9 @@ Each alpha lands on two tags: `alpha`, declared in `publishConfig` so a manual p
 
 `release:alpha` bumps *before* it publishes, so the version in the manifest always equals the last published one.
 
-Publish from CI, not from a laptop: the workflow points at `registry.npmjs.org` through `setup-node` and authenticates with `NPM_TOKEN`, whereas a local `npm config` may resolve to a corporate proxy that refuses the write. Keep `.npmrc` out of the repo for the same reason.
+Publish from CI, not from a laptop: the workflow points at `registry.npmjs.org` through `setup-node`, whereas a local `npm config` may resolve to a corporate proxy that refuses the write. Keep `.npmrc` out of the repo for the same reason.
+
+The two tracks authenticate differently. `@nuxtjs/mcp-toolkit` belongs to the Nuxt team and uses `NPM_TOKEN`; `nitro-mcp-toolkit` belongs to a personal account, so that same token gets a 404 on it — npm's way of saying "not authorized". It uses `NPM_TOKEN_ALPHA` instead, a granular token scoped to that single package.
 
 The bump uses `npm --no-workspaces version`, since both `pnpm version` and plain `npm version` walk the workspace, hit the `workspace:*` ranges in the apps, and exit non-zero *after* writing the new version — which would bump without publishing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,9 @@ The two published packages release on separate tracks, because changesets' prere
 | `@nuxtjs/mcp-toolkit` | Stable, `latest` tag | Changesets. Add a changeset, merge, the `release` workflow opens a version PR |
 | `nitro-mcp-toolkit` | Alpha, `alpha` tag | The `release-alpha` workflow, run manually. Bumps the prerelease, publishes, commits the bump |
 
-`nitro-mcp-toolkit` is listed in `ignore` in `.changeset/config.json`, so a changeset naming it produces no bump — that is deliberate, not a bug to fix. `prepack` runs `obuild` so a stale `dist` can never be published, which matters because `dev:prepare` leaves stubs there.
+`nitro-mcp-toolkit` is listed in `ignore` in `.changeset/config.json`, so a changeset naming it produces no bump — that is deliberate, not a bug to fix.
+
+**`ignore` covers versioning only.** `changeset publish` selects packages with a single filter, `!packageJson.private`, then publishes every one whose version is absent from npm. The two tracks therefore stay apart on one condition: the version of `nitro-mcp-toolkit` on `main` must always be a version that exists on npm. `release:alpha` upholds it by publishing before it commits the bump, and CI enforces it on every PR. Never bump that version by hand. `prepack` runs `obuild` so a stale `dist` can never be published, which matters because `dev:prepare` leaves stubs there.
 
 Each alpha lands on two tags: `alpha`, declared in `publishConfig` so a manual publish cannot claim `latest` by accident, and then `latest`, moved by `release:latest`. The toolkit has no stable release competing for `latest`, so leaving it behind would serve a placeholder to anyone running `npm i nitro-mcp-toolkit`.
 

--- a/packages/nitro-mcp-toolkit/package.json
+++ b/packages/nitro-mcp-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nitro-mcp-toolkit",
-  "version": "0.1.0-alpha.0",
+  "version": "0.0.1",
   "description": "Framework-agnostic MCP server toolkit built directly on Nitro v3 and the MCP SDK v2.",
   "keywords": [
     "ai",
@@ -48,7 +48,7 @@
     "lint:fix": "oxlint . --fix && oxfmt .",
     "lint:package": "publint && attw --pack . --profile esm-only",
     "prepack": "obuild",
-    "release:alpha": "npm --no-workspaces version prerelease --preid alpha --no-git-tag-version && pnpm publish --tag alpha --no-git-checks && pnpm run release:latest",
+    "release:alpha": "npm --no-workspaces version ${BUMP:-prerelease} --preid alpha --no-git-tag-version && pnpm publish --tag alpha --no-git-checks && pnpm run release:latest",
     "release:latest": "npm --no-workspaces dist-tag add nitro-mcp-toolkit@$npm_package_version latest",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
Merging #299 turned the `release` workflow red on `main`: changesets tried to publish `nitro-mcp-toolkit` and failed.

## What went wrong

`ignore` in `.changeset/config.json` only covers **versioning**. `changeset publish` selects packages with a single filter, then publishes every one whose version is absent from npm:

```js
const publicPackages = packages.filter(pkg => !pkg.packageJson.private);
const unpublishedPackagesInfo = await getUnpublishedPackages(publicPackages, preState);
```

So `0.1.0-alpha.0`, which sat on `main` without ever being published, was picked up by the stable release flow.

## The fix

The two release tracks stay apart on one condition: the version of `nitro-mcp-toolkit` on `main` must always be a version that exists on npm. `release:alpha` already upholds it by publishing before it commits the bump — the flaw was purely the bootstrap, a hand-written version that was never released.

The version goes back to `0.0.1`, which is on npm, so the stable release skips it. CI now fails any PR that would put an unpublished version on `main`, so this cannot recur.

The alpha workflow takes the bump as an input, because reaching `0.1.0-alpha.0` from `0.0.1` needs `preminor`, while every release after it needs `prerelease`.

## Publishing rights

The publish also failed with `E404`, which is how npm reports "not authorized": `nitro-mcp-toolkit` is owned by a personal account, while the CI `NPM_TOKEN` belongs to the Nuxt org. The alpha workflow now authenticates with its own `NPM_TOKEN_ALPHA` and fails with that explanation when the secret is missing, instead of surfacing a bare 404.

**Before running `release-alpha`:** add `NPM_TOKEN_ALPHA` to the repository secrets — a granular npm token scoped to `nitro-mcp-toolkit` only, with read and write access. Then run the workflow with `bump: preminor` for the first release, which produces `0.1.0-alpha.0`.