### PR TITLE
fix(module): send notifications on the stream of the request being handled

### DIFF
--- a/.changeset/notify-on-the-request-stream.md
+++ b/.changeset/notify-on-the-request-stream.md
@@ -1,0 +1,5 @@
+---
+"@nuxtjs/mcp-toolkit": patch
+---
+
+Send `log.notify.*` on the stream of the request being handled, so a notification emitted from a tool, resource or prompt is no longer lost. It previously went to the client's standalone SSE stream, which the client opens only after `connect()` returns — anything sent before then, including from the first tool call, was dropped. The client's `logging/setLevel` is still honoured.

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/prompts.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/prompts.ts
@@ -5,6 +5,7 @@ import type { McpServer, PromptCallback } from '@modelcontextprotocol/sdk/server
 import type { ShapeOutput } from '@modelcontextprotocol/sdk/server/zod-compat.js'
 import type { McpRequestExtra } from './sdk-extra'
 import { enrichNameTitle } from './utils'
+import { rememberRequestNotifier } from '../notifications'
 
 /**
  * Return type for MCP prompt handlers.
@@ -98,6 +99,7 @@ export function registerPromptFromDefinition<Args extends ZodRawShape | undefine
 
   const role = prompt.role ?? 'user'
   const wrappedHandler: PromptCallback<ZodRawShape> = async (...args: unknown[]) => {
+    rememberRequestNotifier(args)
     const result = await (prompt.handler as (...a: unknown[]) => unknown)(...args)
     return normalizePromptResult(result as McpPromptCallbackResult, role)
   }

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/resources.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/resources.ts
@@ -6,6 +6,7 @@ import { resolve, extname, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { enrichNameTitle } from './utils'
 import { type McpCacheOptions, type McpCache, createCacheOptions, wrapWithCache } from './cache'
+import { rememberRequestNotifier } from '../notifications'
 
 /**
  * Optional annotations for a resource (from `@modelcontextprotocol/sdk` `Annotations`).
@@ -217,12 +218,18 @@ export function registerResourceFromDefinition(
     ) as ReadResourceCallback
   }
 
+  const readHandler = handler as (...args: unknown[]) => unknown
+  const tracked = (...args: unknown[]) => {
+    rememberRequestNotifier(args)
+    return readHandler(...args)
+  }
+
   if (typeof uri === 'string') {
     return server.registerResource(
       name,
       uri,
       metadata,
-      handler as ReadResourceCallback,
+      tracked as ReadResourceCallback,
     )
   }
   else {
@@ -230,7 +237,7 @@ export function registerResourceFromDefinition(
       name,
       uri,
       metadata,
-      handler as ReadResourceTemplateCallback,
+      tracked as ReadResourceTemplateCallback,
     )
   }
 }

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/tools.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/definitions/tools.ts
@@ -7,6 +7,7 @@ import type { McpRequestExtra } from './sdk-extra'
 import { enrichNameTitle } from './utils'
 import { type MsCacheDuration, type McpCacheOptions, type McpCache, createCacheOptions, wrapWithCache } from './cache'
 import { type McpToolCallbackResult, normalizeToolResult } from './results'
+import { rememberRequestNotifier } from '../notifications'
 
 export type { McpToolCallbackResult }
 
@@ -154,6 +155,7 @@ export function registerToolFromDefinition(
 
   // Normalize returns and catch thrown errors into isError results
   const normalizedHandler: ToolCallback<ZodRawShape> = async (...args: unknown[]) => {
+    rememberRequestNotifier(args)
     try {
       const result = await (handler as (...a: unknown[]) => unknown)(...args)
       return normalizeToolResult(result as McpToolCallbackResult)

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/logger.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/logger.ts
@@ -4,11 +4,12 @@ import type { H3Event } from 'h3'
 import { getHeader } from './compat'
 import { useMcpServer } from './server'
 import { getEvlogLogger, getSdkServerFromHelper } from './internals'
+import { getRequestNotifier, isLevelEnabled } from './notifications'
 
 /**
  * Sends `notifications/message` to the connected MCP client. Honours the
- * client's `logging/setLevel` per session and never throws — disconnects
- * and filtered levels are silently dropped.
+ * client's `logging/setLevel` and never throws — disconnects and filtered
+ * levels are silently dropped.
  */
 export interface McpClientNotifier {
   (level: LoggingLevel, data: unknown, logger?: string): Promise<void>
@@ -98,11 +99,21 @@ export function useMcpLogger(prefix?: string): McpLogger {
 
   const sendNotify = async (level: LoggingLevel, data: unknown, logger?: string): Promise<void> => {
     try {
-      await sdkServer.sendLoggingMessage({
-        level,
-        data,
-        logger: logger ?? prefix,
-      }, sessionId)
+      if (!isLevelEnabled(helper.server, level)) return
+
+      const params = { level, data, logger: logger ?? prefix }
+
+      // Inside a handler, the request's own stream is the only one a client is
+      // guaranteed to be reading: the standalone SSE stream is opened after
+      // `connect()` returns, so a notification sent before then is dropped.
+      const notifyRequest = getRequestNotifier(event)
+
+      if (notifyRequest) {
+        await notifyRequest({ method: 'notifications/message', params })
+      }
+      else {
+        await sdkServer.sendLoggingMessage(params, sessionId)
+      }
     }
     catch (err) {
       if (requestLogger) {

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/notifications.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/notifications.ts
@@ -1,0 +1,93 @@
+import { LoggingLevelSchema, SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import type { LoggingLevel } from '@modelcontextprotocol/sdk/types.js'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { H3Event } from 'h3'
+import { useEvent } from 'nitropack/runtime'
+import { getSdkServer } from './internals'
+import type { McpRequestExtra } from './definitions/sdk-extra'
+
+/**
+ * Sends a notification down the stream the client is already reading for the
+ * request being handled. This is `sendNotification` from the SDK's
+ * `RequestHandlerExtra`.
+ */
+export type McpRequestNotifier = McpRequestExtra['sendNotification']
+
+const notifiers = new WeakMap<H3Event, McpRequestNotifier>()
+const floors = new WeakMap<McpServer, LoggingLevel>()
+
+const SEVERITY = new Map(LoggingLevelSchema.options.map((level, index) => [level, index]))
+
+function severityOf(level: LoggingLevel): number {
+  return SEVERITY.get(level) ?? 0
+}
+
+function currentEvent(): H3Event | null {
+  try {
+    return useEvent()
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * The SDK hands each definition handler a notifier bound to the request; it is
+ * the only channel that reaches a client which has not opened the standalone
+ * SSE stream. Duck-typed because `extra` arrives as the callback's last
+ * argument, whose position depends on the shape the definition declared.
+ */
+function notifierOf(value: unknown): McpRequestNotifier | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const candidate = (value as { sendNotification?: unknown }).sendNotification
+  return typeof candidate === 'function' ? candidate as McpRequestNotifier : undefined
+}
+
+/**
+ * Remember the notifier for the request being handled, so `useMcpLogger` can
+ * answer on its stream. Called with a definition callback's own arguments.
+ *
+ * @internal
+ */
+export function rememberRequestNotifier(args: readonly unknown[]): void {
+  const notifier = notifierOf(args.at(-1))
+  const event = currentEvent()
+  if (notifier && event) {
+    notifiers.set(event, notifier)
+  }
+}
+
+/** @internal */
+export function getRequestNotifier(event: H3Event | null | undefined): McpRequestNotifier | undefined {
+  return event ? notifiers.get(event) : undefined
+}
+
+/**
+ * Track `logging/setLevel` for this server. The SDK records it too, but keeps
+ * it private and applies it only in `sendLoggingMessage` — the channel a
+ * mid-request notification cannot use — so the filter has to be readable here.
+ *
+ * One level per server instance is enough: a server serves one session when
+ * sessions are on, and one request when they are off.
+ *
+ * @internal
+ */
+export function trackLoggingLevel(server: McpServer): void {
+  getSdkServer(server).setRequestHandler(SetLevelRequestSchema, async (request) => {
+    const parsed = LoggingLevelSchema.safeParse(request.params.level)
+    if (parsed.success) {
+      floors.set(server, parsed.data)
+    }
+    return {}
+  })
+}
+
+/**
+ * Whether the client still wants messages of this level.
+ *
+ * @internal
+ */
+export function isLevelEnabled(server: McpServer, level: LoggingLevel): boolean {
+  const floor = floors.get(server)
+  return floor === undefined || severityOf(level) >= severityOf(floor)
+}

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/utils.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/utils.ts
@@ -13,6 +13,7 @@ import { registerToolFromDefinition } from './definitions/tools'
 import type { CodeModeOptions } from './codemode'
 import { getHeader, getRequestMethod } from './compat'
 import { getEvlogLogger } from './internals'
+import { trackLoggingLevel } from './notifications'
 import handleMcpRequest from '#nuxt-mcp-toolkit/transport.mjs'
 
 export type { McpTransportHandler } from './providers/types'
@@ -127,6 +128,8 @@ export async function createMcpServer(config: McpResolvedConfig): Promise<McpSer
       logging: {},
     },
   })
+
+  trackLoggingLevel(server)
 
   let toolsToRegister: McpToolDefinition[] = config.tools as McpToolDefinition[]
 


### PR DESCRIPTION
## Why

`test/logger.test.ts > lets the per-call logger override take precedence over the prefix` has been failing on and off, including on `main` ([d81ea81](https://github.com/nuxt-modules/mcp-toolkit/commit/d81ea81)), with `expected [] to deeply equal [ 'default-prefix', 'override-prefix' ]` — no notification arrived at all.

It is not a slow test. `log.notify.*` calls `Server.sendLoggingMessage`, which the SDK routes with no `relatedRequestId`:

```js
async sendLoggingMessage(params, sessionId) {
    if (this._capabilities.logging) {
        if (!this.isMessageIgnored(params.level, sessionId)) {
            return this.notification({ method: 'notifications/message', params });
        }
    }
}
```

Without one, the transport delivers on the client's **standalone SSE stream**, which `StreamableHTTPClientTransport` opens asynchronously *after* `connect()` returns. A tool called right away therefore sends its notifications into a stream that does not exist yet, and they are dropped. A 500 ms pause after connecting makes the test pass every time, which is what pinned the cause down — and a client that never opens a standalone stream never receives anything.

## What

- Definitions remember the notifier the SDK hands them as they are entered, and `useMcpLogger` sends on it, so notifications go down the stream the client is already reading for that request. `sendLoggingMessage` stays as the fallback for a caller outside any handler.
- `logging/setLevel` is tracked in the module as a result: the SDK keeps its copy private and consults it only in `sendLoggingMessage`, so the filter has to be readable from the channel that replaced it. One level per server instance is enough — a server serves one session with sessions on, one request without.

No public API changes.

## Test plan

- [x] `test/logger.test.ts` passes, three runs in a row, the previously failing case in 12 ms instead of timing out
- [x] `honors the logging/setLevel filter set by the client` still passes, covering the tracked filter
- [x] `test/logger-disabled.test.ts` passes, covering the `mcp.logging: false` path
- [x] Full package suite, lint and typecheck
- [ ] Unrelated: `test/codemode-executor.test.ts > executor concurrency` times out under a saturated machine, on `main` as well as here. Separate flake, not touched by this PR.