### PR TITLE
fix(nitro): refuse a browser origin unless it is the app's own

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,8 @@ The runtime imports exactly one Node built-in, `node:async_hooks`, for the `Asyn
 
 Windows is covered by a dedicated `test-windows` CI job that runs this package's suite alone, since it is the only one whose behaviour depends on the OS. Its e2e test builds a real Nitro app, which is what proves the absolute paths in the generated registry resolve there.
 
+**The SDK does no `Origin` validation of its own, so `createMcpHandler` adds one** (`src/runtime/origin.ts`), checked ahead of `sdk.fetch` in both `handle` and `fetch`. The default accepts a page the app serves to itself on a loopback host and refuses every other origin; requests with no `Origin` — every MCP client proper — are unaffected. The loopback condition is not decoration: `event.url` reads the `Host` header, so a bare same-origin comparison is satisfied by DNS rebinding, where the attacker's own hostname lands in both `Host` and `Origin`. Do not drop it to "simplify" the check. `allow` adds explicit origins on top of the default; a user's own `allow` list does not cost the loopback case.
+
 ### MCP Definitions
 
 Use the helper functions:

--- a/packages/nitro-mcp-toolkit/README.md
+++ b/packages/nitro-mcp-toolkit/README.md
@@ -89,10 +89,25 @@ mcp({
   websiteUrl: 'https://example.com',
   instructions: 'What the model is told about this server as a whole',
   legacy: 'stateless', // or 'reject', for a 2026-07-28-only endpoint
+  origin: { allow: ['https://app.example.com'] }, // browser clients, see below
 })
 ```
 
 These cross into generated code, so they are data only. A server that needs `bus` or `onError` mounts the handler by hand instead — see [Wiring it by hand](#wiring-it-by-hand).
+
+### Browser clients
+
+MCP clients send no `Origin` header, so this decides one thing only: which **web pages** may drive your server. A page the app serves to itself over a loopback host is accepted, which is why a browser tool works in development with nothing to configure, and every other origin is refused — that is what stops a page on some other host from driving a server bound to localhost.
+
+Deployed elsewhere, that page's origin has to be named:
+
+```ts
+mcp({ origin: { allow: ['https://app.example.com'] } })
+```
+
+An origin is matched exactly, scheme and port included. Pass `origin: false` to drop the check — reasonable for a public endpoint where a token, not the origin, is the boundary.
+
+The loopback condition is the load-bearing part of the default: `Origin` can only be compared against the request's own origin when the host is a loopback address. Everywhere else the host comes from a header the caller sets, and DNS rebinding — the attack this check exists to stop — sends the attacker's hostname in both, so a bare same-origin comparison always agrees with itself.
 
 ### More than one server
 

--- a/packages/nitro-mcp-toolkit/src/module/options.ts
+++ b/packages/nitro-mcp-toolkit/src/module/options.ts
@@ -31,6 +31,17 @@ export interface McpServerOptions {
    * @default 'auto'
    */
   responseMode?: PerRequestResponseMode
+  /**
+   * Browser origins allowed beyond the app's own loopback pages, which pass by
+   * default. Requests carrying no `Origin` — every MCP client proper — are
+   * unaffected. `false` drops the check.
+   *
+   * @example
+   * ```ts
+   * mcp({ origin: { allow: ['https://app.example.com'] } })
+   * ```
+   */
+  origin?: false | { allow?: string[]; allowMissing?: boolean }
 }
 
 export interface McpModuleOptions extends McpServerOptions {

--- a/packages/nitro-mcp-toolkit/src/runtime/handler.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/handler.ts
@@ -1,6 +1,7 @@
 import { createMcpHandler as createSdkHandler, McpServer } from '@modelcontextprotocol/server'
 import { H3Event } from 'h3'
 import { runWithRequest, setEra } from './context.ts'
+import { forbiddenOriginResponse, isOriginAllowed } from './origin.ts'
 import { resolveDefinitions, summarize } from './validate.ts'
 import type {
   Icon,
@@ -10,6 +11,7 @@ import type {
   ServerNotifier,
 } from '@modelcontextprotocol/server'
 import type { McpDefinitionSummary, McpPrompt, McpResource, McpTool } from './definition.ts'
+import type { McpOriginOptions } from './origin.ts'
 
 export interface McpHandlerOptions {
   /** Advertised to clients during initialization. */
@@ -40,6 +42,17 @@ export interface McpHandlerOptions {
    * @default 'auto'
    */
   responseMode?: PerRequestResponseMode
+  /**
+   * Which browser origins may reach the endpoint, beyond the pages the app
+   * serves to itself over loopback, which are accepted by default. Requests
+   * carrying no `Origin` are unaffected. `false` drops the check.
+   *
+   * @example
+   * ```ts
+   * createMcpHandler({ origin: { allow: ['https://app.example.com'] } })
+   * ```
+   */
+  origin?: McpOriginOptions
   /**
    * The change-event bus backing `subscriptions/listen`. Supply a shared
    * implementation to notify clients from several processes.
@@ -92,7 +105,7 @@ export interface McpHandler {
  * ```
  */
 export function createMcpHandler(options: McpHandlerOptions = {}): McpHandler {
-  const { tools = [], resources = [], prompts = [] } = options
+  const { tools = [], resources = [], prompts = [], origin } = options
   const registrations = resolveDefinitions([...tools, ...resources, ...prompts])
 
   const sdk = createSdkHandler(
@@ -129,11 +142,18 @@ export function createMcpHandler(options: McpHandlerOptions = {}): McpHandler {
 
   // Driven bare, there is no Nitro event to carry, so one is synthesized over
   // the request: handlers get a consistent `ctx.event` either way.
-  const fetch: McpHandler['fetch'] = (request, requestOptions) =>
-    runWithRequest(new H3Event(request), () => sdk.fetch(request, requestOptions))
+  const fetch: McpHandler['fetch'] = (request, requestOptions) => {
+    const event = new H3Event(request)
+    if (!isOriginAllowed(event, origin)) return Promise.resolve(forbiddenOriginResponse())
 
-  const handle = (event: H3Event): Promise<Response> =>
-    runWithRequest(event, () => sdk.fetch(event.req))
+    return runWithRequest(event, () => sdk.fetch(request, requestOptions))
+  }
+
+  const handle = (event: H3Event): Promise<Response> => {
+    if (!isOriginAllowed(event, origin)) return Promise.resolve(forbiddenOriginResponse())
+
+    return runWithRequest(event, () => sdk.fetch(event.req))
+  }
 
   return Object.assign(handle, {
     fetch,

--- a/packages/nitro-mcp-toolkit/src/runtime/index.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/index.ts
@@ -28,6 +28,7 @@ export type {
   McpResource,
   McpTool,
 } from './definition.ts'
+export type { McpOriginOptions } from './origin.ts'
 export type { McpToolValue } from './results.ts'
 export type { McpToolDefinition, McpToolDefinitionWithoutInput, McpToolReturn } from './tool.ts'
 

--- a/packages/nitro-mcp-toolkit/src/runtime/origin.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/origin.ts
@@ -1,0 +1,38 @@
+import type { H3Event } from 'h3'
+
+export type McpOriginOptions = false | { allow?: string[]; allowMissing?: boolean }
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1'])
+
+// The loopback test is not optional: `event.url` reads the `Host` header, which
+// DNS rebinding sets to the attacker's own name — matching its `Origin`.
+function sameLoopbackOrigin(origin: string, event: H3Event): boolean {
+  return origin === event.url.origin && LOOPBACK_HOSTS.has(event.url.hostname)
+}
+
+/**
+ * Whether a browser is allowed to drive this endpoint. Requests carrying no
+ * `Origin` — every MCP client proper — are unaffected by anything here.
+ *
+ * @internal
+ */
+export function isOriginAllowed(event: H3Event, origin: McpOriginOptions | undefined): boolean {
+  if (origin === false) return true
+
+  const header = event.req.headers.get('origin')
+  if (!header) return origin?.allowMissing ?? true
+
+  return origin?.allow?.includes(header) || sameLoopbackOrigin(header, event)
+}
+
+/** @internal */
+export function forbiddenOriginResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32_600, message: 'Origin not allowed' },
+    }),
+    { status: 403, headers: { 'content-type': 'application/json' } },
+  )
+}

--- a/packages/nitro-mcp-toolkit/test/module.test.ts
+++ b/packages/nitro-mcp-toolkit/test/module.test.ts
@@ -114,6 +114,7 @@ describe('the mcp() module', () => {
           route: '/iconic',
           icons: [{ src: 'https://example.com/icon.png', mimeType: 'image/png' }],
           websiteUrl: 'https://example.com',
+          origin: { allow: ['https://app.example.com'] },
         }),
       ],
     })
@@ -122,6 +123,7 @@ describe('the mcp() module', () => {
 
     expect(code).toContain('icons: [{"src":"https://example.com/icon.png","mimeType":"image/png"}]')
     expect(code).toContain('websiteUrl: "https://example.com"')
+    expect(code).toContain('origin: {"allow":["https://app.example.com"]}')
 
     await iconic.close()
   })

--- a/packages/nitro-mcp-toolkit/test/origin.test.ts
+++ b/packages/nitro-mcp-toolkit/test/origin.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { createMcpHandler, defineMcpTool } from '../src/runtime/index.ts'
+import { createMcpTestClient } from '../src/testing/index.ts'
+import type { McpHandlerOptions } from '../src/runtime/index.ts'
+
+// MCP clients proper send no `Origin`, so these tests forge one by hand — the
+// SDK client used everywhere else in this suite never would.
+function withOrigin(
+  origin: string | undefined,
+  handlerOptions: McpHandlerOptions = {},
+  url?: string,
+) {
+  const handler = createMcpHandler({
+    tools: [defineMcpTool({ name: 'ping', handler: () => 'pong' })],
+    ...handlerOptions,
+  })
+
+  return createMcpTestClient(
+    {
+      fetch: (request, options) => {
+        const headers = new Headers(request.headers)
+        if (origin) headers.set('origin', origin)
+        return handler.fetch(new Request(request, { headers }), options)
+      },
+    },
+    { url },
+  )
+}
+
+describe('which browsers reach the endpoint', () => {
+  it('serves a page the app serves to itself in development', async () => {
+    await using client = await withOrigin('http://localhost')
+
+    await expect(client.callTool({ name: 'ping' })).resolves.toBeDefined()
+  })
+
+  it('refuses a page on another origin', async () => {
+    await expect(withOrigin('https://evil.example')).rejects.toThrow()
+  })
+
+  it('refuses a matching origin the request itself claims', async () => {
+    // The DNS rebinding shape: the attacker owns the hostname, so both headers
+    // agree and a bare same-origin comparison lets it through.
+    await expect(withOrigin('http://evil.example', {}, 'http://evil.example/mcp')).rejects.toThrow()
+  })
+
+  it('serves an origin that was listed, wherever it is deployed', async () => {
+    const options = { origin: { allow: ['https://app.example.com'] } }
+    const url = 'https://api.example.com/mcp'
+
+    await using client = await withOrigin('https://app.example.com', options, url)
+    await expect(client.callTool({ name: 'ping' })).resolves.toBeDefined()
+
+    await expect(withOrigin('https://other.example', options, url)).rejects.toThrow()
+  })
+
+  it('still lets a listed server keep its own pages in development', async () => {
+    await using client = await withOrigin('http://localhost', {
+      origin: { allow: ['https://app.example.com'] },
+    })
+
+    await expect(client.callTool({ name: 'ping' })).resolves.toBeDefined()
+  })
+
+  it('leaves clients that send no origin alone', async () => {
+    await using client = await withOrigin(undefined, {}, 'https://api.example.com/mcp')
+
+    await expect(client.callTool({ name: 'ping' })).resolves.toBeDefined()
+  })
+
+  it('drops the check entirely on request', async () => {
+    await using client = await withOrigin('https://evil.example', { origin: false })
+
+    await expect(client.callTool({ name: 'ping' })).resolves.toBeDefined()
+  })
+})


### PR DESCRIPTION
The SDK's createMcpHandler does no Origin validation of its own, so any page could drive the endpoint from a browser. createMcpHandler now checks Origin ahead of the SDK, in both handle and fetch, and returns 403 for anything it refuses.

The default accepts a page the app serves to itself on a loopback host — so a dev-time browser client needs no configuration — and refuses everything else; requests with no Origin, which is every MCP client proper, are unaffected. `origin.allow` lists origins a deployed page is served from, on top of the default; `origin: false` drops the check.

The loopback condition is load-bearing, not incidental: `event.url` reads the Host header, which the caller sets, so a bare same-origin comparison is satisfied by DNS rebinding — the attacker's own hostname lands in both Host and Origin. Comparing against a loopback host closes that gap.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- docs (the documentation)
- playground (the playground)
- module (the module)
- deps (dependencies of the project)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
