### PR TITLE
feat(nitro): add explicit tool result helper

### DIFF
--- a/.changeset/explicit-tool-results.md
+++ b/.changeset/explicit-tool-results.md
@@ -1,0 +1,5 @@
+---
+"nitro-mcp-toolkit": minor
+---
+
+Add `toolResult()` for handlers that intentionally return a full MCP `CallToolResult` while also declaring an `outputSchema`. This keeps explicit protocol fields such as `isError` and `structuredContent` intact without reintroducing heuristics that could misclassify domain output with protocol-looking field names.

--- a/packages/nitro-mcp-toolkit/README.md
+++ b/packages/nitro-mcp-toolkit/README.md
@@ -191,15 +191,16 @@ export default defineMcpTool({
 
 Return whatever is natural; the toolkit builds the protocol result.
 
-| You return                  | The client receives           |
-| --------------------------- | ----------------------------- |
-| `string`                    | one text block                |
-| `number`, `boolean`         | one text block, stringified   |
-| `null`, `undefined`         | no content                    |
-| object, array               | one text block of pretty JSON |
-| a full `CallToolResult`     | used as-is                    |
-| `imageResult(base64, mime)` | an image block                |
-| `audioResult(base64, mime)` | an audio block                |
+| You return                  | The client receives                                        |
+| --------------------------- | ---------------------------------------------------------- |
+| `string`                    | one text block                                             |
+| `number`, `boolean`         | one text block, stringified                                |
+| `null`, `undefined`         | no content                                                 |
+| object, array               | one text block of pretty JSON                              |
+| a full `CallToolResult`     | used as-is without `outputSchema`                          |
+| `toolResult(result)`        | an explicit protocol result, including with `outputSchema` |
+| `imageResult(base64, mime)` | an image block                                             |
+| `audioResult(base64, mime)` | an audio block                                             |
 
 ### Structured output
 
@@ -214,6 +215,43 @@ export default defineMcpTool({
 ```
 
 A return that doesn't actually satisfy a declared `outputSchema` is a protocol error (`-32602`), not an `isError` result — the engine validates the advertised shape after the handler returns.
+
+When a structured failure is part of the advertised output contract, use `toolResult()` to make the protocol result explicit while keeping the domain schema unambiguous:
+
+```ts
+import { defineMcpTool, toolResult } from 'nitro-mcp-toolkit'
+import { z } from 'zod'
+
+export default defineMcpTool({
+  inputSchema: z.object({ key: z.string() }),
+  outputSchema: z.object({
+    success: z.boolean(),
+    message: z.string().min(1).regex(/\S/),
+    error_code: z
+      .string()
+      .regex(/^[a-z][a-z0-9_]*$/)
+      .optional(),
+    value: z.string().optional(),
+  }),
+  handler: async ({ key }) => {
+    const value = await getSetting(key)
+    if (value === undefined) {
+      return toolResult({
+        structuredContent: {
+          success: false,
+          message: `Setting "${key}" was not found.`,
+          error_code: 'setting_not_found',
+        },
+        isError: true,
+      })
+    }
+
+    return { success: true, message: `Setting "${key}" returned.`, value }
+  },
+})
+```
+
+Without `toolResult()`, an object returned by a tool with `outputSchema` is deliberately treated as domain output, even if it contains protocol-looking keys such as `content` or `isError`. That keeps schemas with those legitimate field names safe from heuristics.
 
 ### Errors
 

--- a/packages/nitro-mcp-toolkit/src/runtime/index.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/index.ts
@@ -4,7 +4,7 @@ export { createMcpHandler } from './handler.ts'
 export { defineMcpPrompt } from './prompt.ts'
 export { MODERN_PROTOCOL_VERSION } from './protocol.ts'
 export { defineMcpResource } from './resource.ts'
-export { audioResult, imageResult } from './results.ts'
+export { audioResult, imageResult, toolResult } from './results.ts'
 export { defineMcpTool } from './tool.ts'
 export {
   canRequestInput,
@@ -41,7 +41,7 @@ export type {
   McpResource,
   McpTool,
 } from './definition.ts'
-export type { McpToolValue } from './results.ts'
+export type { McpToolResult, McpToolValue } from './results.ts'
 export type { McpToolDefinition, McpToolDefinitionWithoutInput, McpToolReturn } from './tool.ts'
 
 export type {

--- a/packages/nitro-mcp-toolkit/src/runtime/results.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/results.ts
@@ -12,6 +12,15 @@ export type McpToolValue =
   | readonly unknown[]
   | Record<string, unknown>
 
+/**
+ * An explicit protocol result before Nitro fills an omitted text fallback.
+ */
+export type McpToolResult = Omit<CallToolResult, 'content'> & {
+  content?: CallToolResult['content']
+}
+
+const explicitToolResults = new WeakSet<object>()
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
 }
@@ -21,6 +30,10 @@ function isObject(value: unknown): value is Record<string, unknown> {
  */
 export function isInputRequired(value: unknown): value is InputRequiredResult {
   return isObject(value) && value.resultType === 'input_required'
+}
+
+function isExplicitToolResult(value: object): value is CallToolResult {
+  return explicitToolResults.has(value)
 }
 
 function isCallToolResult(value: object): value is CallToolResult {
@@ -35,6 +48,35 @@ function textBlock(text: string): ContentBlock[] {
   return [{ type: 'text', text }]
 }
 
+function finalizeToolResult(value: McpToolResult): CallToolResult {
+  if (value.isError && !value.content?.length) {
+    const text = value.structuredContent
+      ? JSON.stringify(value.structuredContent)
+      : 'Tool execution failed'
+    return { ...value, content: textBlock(text) }
+  }
+
+  if (value.structuredContent && !value.content?.length) {
+    return { ...value, content: textBlock(JSON.stringify(value.structuredContent)) }
+  }
+
+  return { ...value, content: value.content ?? [] }
+}
+
+/**
+ * Mark a full protocol result as intentional.
+ *
+ * This disambiguates it from ordinary domain output when an `outputSchema` is
+ * declared and that domain shape itself may contain protocol-looking keys.
+ * `content` may be omitted when `structuredContent` is present; Nitro generates
+ * the same text fallback it uses for other structured results.
+ */
+export function toolResult(result: McpToolResult): CallToolResult {
+  const normalized = finalizeToolResult(result)
+  explicitToolResults.add(normalized)
+  return normalized
+}
+
 /**
  * Coerce a handler return into a `CallToolResult`.
  *
@@ -42,10 +84,15 @@ function textBlock(text: string): ContentBlock[] {
  * value goes straight to `structuredContent` for the engine to validate.
  * Sniffing it for protocol keys instead would break any schema that happens
  * to describe a `content` array, and the schema could never be satisfied.
+ * `toolResult()` is the explicit escape hatch when the handler intentionally
+ * returns protocol fields alongside an output schema.
  *
  * @internal
  */
 export function toCallToolResult(value: unknown, hasOutputSchema: boolean): CallToolResult {
+  if (isObject(value) && isExplicitToolResult(value)) {
+    return finalizeToolResult(value)
+  }
   if (hasOutputSchema && isObject(value)) {
     return { content: textBlock(JSON.stringify(value, null, 2)), structuredContent: value }
   }
@@ -66,18 +113,7 @@ export function toCallToolResult(value: unknown, hasOutputSchema: boolean): Call
     return { content: textBlock(JSON.stringify(value, null, 2)) }
   }
 
-  if (value.isError && !value.content?.length) {
-    const text = value.structuredContent
-      ? JSON.stringify(value.structuredContent)
-      : 'Tool execution failed'
-    return { ...value, content: textBlock(text) }
-  }
-
-  if (value.structuredContent && !value.content?.length) {
-    return { ...value, content: textBlock(JSON.stringify(value.structuredContent)) }
-  }
-
-  return value
+  return finalizeToolResult(value)
 }
 
 /**

--- a/packages/nitro-mcp-toolkit/test/surface.test.ts
+++ b/packages/nitro-mcp-toolkit/test/surface.test.ts
@@ -26,6 +26,7 @@ describe('public exports', () => {
         "inputRequired",
         "mcpElicit",
         "mcpElicitUrl",
+        "toolResult",
       ]
     `)
   })

--- a/packages/nitro-mcp-toolkit/test/tool.test.ts
+++ b/packages/nitro-mcp-toolkit/test/tool.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { createMcpHandler, defineMcpTool } from '../src/runtime/index.ts'
+import { createMcpHandler, defineMcpTool, toolResult } from '../src/runtime/index.ts'
 import { createMcpTestClient } from '../src/testing/index.ts'
 import type { CallToolResult } from '../src/runtime/index.ts'
 
@@ -137,6 +137,35 @@ describe('defineMcpTool', () => {
     const result = await client.callTool({ name: 'bmi', arguments: { weightKg: 70, heightM: 2 } })
     expect(result.structuredContent).toEqual({ bmi: 17.5 })
     expect(result.content).toEqual([{ type: 'text', text: '{\n  "bmi": 17.5\n}' }])
+  })
+
+  it('passes an explicit tool result through when an output schema is declared', async () => {
+    const structuredContent = {
+      success: false,
+      message: 'The setting was not found.',
+      error_code: 'setting_not_found',
+    }
+    await using client = await createMcpTestClient(
+      serve(
+        defineMcpTool({
+          name: 'setting',
+          outputSchema: z.object({
+            success: z.boolean(),
+            message: z.string().min(1).regex(/\S/),
+            error_code: z
+              .string()
+              .regex(/^[a-z][a-z0-9_]*$/)
+              .optional(),
+          }),
+          handler: () => toolResult({ structuredContent, isError: true }),
+        }),
+      ),
+    )
+
+    const result = await client.callTool({ name: 'setting' })
+    expect(result.isError).toBe(true)
+    expect(result.structuredContent).toEqual(structuredContent)
+    expect(result.content).toEqual([{ type: 'text', text: JSON.stringify(structuredContent) }])
   })
 
   // An output schema is a promise about the return shape, so it must win over


### PR DESCRIPTION
### Linked issue

Closes #315

### Description

Add an explicit `toolResult()` escape hatch for tools that intentionally return protocol fields while also declaring an `outputSchema`.

Today, `outputSchema` correctly takes precedence over protocol-looking object keys so domain schemas such as `{ content: string[] }` remain valid. The missing case is an intentional `CallToolResult`: without an explicit signal, `structuredContent` + `isError` are interpreted as the domain object itself.

This change:

- adds `toolResult()` as an explicit, non-wire marker for intentional protocol results;
- preserves the existing behavior for all unmarked domain objects;
- allows `content` to be omitted when `structuredContent` is available, using Nitro's existing text fallback;
- documents structured in-band failures without changing the ordinary `throw` path;
- adds regression coverage and updates the public export snapshot;
- includes a minor changeset for `nitro-mcp-toolkit`.

### Validation

Validated on the repository-pinned Node `24.18.0` with pnpm `11.17.0`:

- `git diff --check`
- focused `oxfmt --check` on all changed package files: pass
- focused `oxlint` on changed TypeScript files: 0 errors (the existing triple-slash warning in `src/runtime/index.ts` remains)
- `pnpm --filter nitro-mcp-toolkit run typecheck`: pass
- `pnpm --filter nitro-mcp-toolkit run build`: pass
- focused tool + public-surface tests: 16/16 pass
- full coverage suite with a 60s hook timeout on this Windows machine: 22/22 test files, 122/122 tests; 96.55% statements, 92.99% branches. The default 10s run hit only the existing Nitro app build hook timeout; with a realistic local build allowance it passes unchanged.

I also captured the real MCP `2026-07-28` HTTP wire, before client decoding, for a structured success/failure pair. The SDK stamped `resultType: "complete"` on both responses and preserved explicit `isError` values. As an independent interoperability check, that pair conforms to [QZX Result Contract v1](https://github.com/alesanGreat/QZX-Quick-Zap-Exchange/blob/main/docs/result-contract-v1.md) in its `structural_core` mode. This is validation only: the change adds no QZX dependency or runtime coupling.

### Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests that prove the behavior.
- [x] I have updated the documentation accordingly.
- [x] I have added a changeset for the public API addition.
