### PR TITLE
feat(module): honor X-MCP-Tools header to subset the tool catalog

### DIFF
--- a/.changeset/x-mcp-tools-header.md
+++ b/.changeset/x-mcp-tools-header.md
@@ -1,0 +1,5 @@
+---
+"@nuxtjs/mcp-toolkit": minor
+---
+
+Clients can send an `X-MCP-Tools` header with a comma-separated list of tool names to limit what `tools/list` exposes. Names must match the catalog (including filename-generated kebab-case); unknown names return HTTP 400. No `server/mcp/index.ts` is required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,10 @@ export default defineMcpPrompt({
 If `name` and `title` are omitted, they are auto-generated from the filename:
 - `list-documentation.ts` → name: `list-documentation`, title: `List Documentation`
 
+### Client tool allowlist
+
+Clients can send `X-MCP-Tools` (comma-separated names matching `tools/list`) to subset the catalog. Unknown names return HTTP 400. Applied after `enabled()` and `mcp:config:resolved`. No `server/mcp/index.ts` required.
+
 ### Return Types
 
 - **Tools**: Return `string`, `number`, `boolean`, object, array (auto-wrapped), or full `CallToolResult`. Use `imageResult` / `audioResult` for image and audio content blocks. Thrown errors become `isError` results.

--- a/apps/docs/content/1.getting-started/5.connection.md
+++ b/apps/docs/content/1.getting-started/5.connection.md
@@ -151,6 +151,39 @@ Or manually add the server to your VS Code MCP configuration (`.vscode/mcp.json`
 Replace `my-nuxt-app` with your project name and update the URL if you're using a custom route or port.
 ::
 
+## Limit available tools
+
+Clients can send the `X-MCP-Tools` HTTP header with a comma-separated list of tool names to expose only those tools. Names must match what `tools/list` returns (including filename-generated kebab-case). Unknown names return HTTP 400. Omit the header to keep the full catalog.
+
+This is applied automatically — no `server/mcp/index.ts` required.
+
+```json [~/.cursor/mcp.json]
+{
+  "mcpServers": {
+    "my-nuxt-app": {
+      "url": "http://localhost:3000/mcp",
+      "headers": {
+        "X-MCP-Tools": "search-icons, get-component"
+      }
+    }
+  }
+}
+```
+
+```json [.vscode/mcp.json]
+{
+  "servers": {
+    "my-nuxt-app": {
+      "type": "http",
+      "url": "http://localhost:3000/mcp",
+      "headers": {
+        "X-MCP-Tools": "search-icons, get-component"
+      }
+    }
+  }
+}
+```
+
 ## InstallButton Component
 
 The module provides an `InstallButton` component that you can use in your documentation to let users install your MCP server in one click.

--- a/apps/docs/content/2.tools/4.groups-organization.md
+++ b/apps/docs/content/2.tools/4.groups-organization.md
@@ -155,6 +155,12 @@ When `enabled` returns `false`, the tool is hidden from `tools/list` and cannot 
 See the [Dynamic Definitions](/advanced/dynamic-definitions) guide for detailed documentation on auth-based filtering.
 ::
 
+## Client allowlist (`X-MCP-Tools`)
+
+Clients can subset the catalog themselves by sending `X-MCP-Tools` with a comma-separated list of names. The toolkit applies this after `enabled()` guards and `mcp:config:resolved`, so the header is the last word on whatever this endpoint would have served. Names must match `tools/list`; unknown names return HTTP 400.
+
+See [Connect MCP clients](/getting-started/connection#limit-available-tools) for Cursor and VS Code config.
+
 ## Next Steps
 
 - [Resources](/resources/overview) - Create resources to expose data

--- a/apps/docs/content/5.handlers/1.default-and-custom.md
+++ b/apps/docs/content/5.handlers/1.default-and-custom.md
@@ -56,6 +56,8 @@ export default defineMcpHandler({
 })
 ```
 
+To let **clients** pick a subset per connection (without a custom handler), they send `X-MCP-Tools`. See [Limit available tools](/getting-started/connection#limit-available-tools).
+
 ## Custom Handlers
 
 Create custom handlers using `defineMcpHandler`:

--- a/apps/docs/content/7.advanced/4.hooks.md
+++ b/apps/docs/content/7.advanced/4.hooks.md
@@ -107,6 +107,9 @@ defineMcpHandler middleware (if any)
 resolveDynamicDefinitions  ──►  mcp:config:resolved
    │
    ▼
+X-MCP-Tools allowlist (if the header is present)
+   │
+   ▼
 createMcpServer            ──►  mcp:server:created
    │
    ▼
@@ -115,7 +118,7 @@ transport.handleRequest
 
 ### `mcp:config:resolved`
 
-Fired after dynamic `tools` / `resources` / `prompts` resolvers and `enabled(event)` guards have run, **before** the per-request `McpServer` is built. Mutate `ctx.config` in place to add, remove or transform definitions for this request only.
+Fired after dynamic `tools` / `resources` / `prompts` resolvers and `enabled(event)` guards have run, **before** the `X-MCP-Tools` allowlist and the per-request `McpServer` is built. Mutate `ctx.config` in place to add, remove or transform definitions for this request only.
 
 #### Hook signature
 

--- a/apps/docs/skills/manage-mcp/SKILL.md
+++ b/apps/docs/skills/manage-mcp/SKILL.md
@@ -418,6 +418,8 @@ export default defineMcpHandler({
 })
 ```
 
+Clients can further subset whatever this endpoint would have served by sending `X-MCP-Tools` (comma-separated names matching `tools/list`). Unknown names return HTTP 400. Applied automatically after `enabled()` and `mcp:config:resolved` — no custom handler needed.
+
 See [handlers reference →](./references/handlers.md).
 
 ---
@@ -472,12 +474,12 @@ See [middleware patterns →](./references/middleware.md).
 Two per-request Nitro hooks fire during the MCP request lifecycle. Subscribe from a `server/plugins/*.ts` plugin to mutate the resolved config or reach the SDK `McpServer` instance from anywhere — no need to own a `defineMcpHandler`. Listeners that throw are logged and the request continues.
 
 ```
-defineMcpHandler middleware → mcp:config:resolved → createMcpServer → mcp:server:created → transport
+defineMcpHandler middleware → mcp:config:resolved → X-MCP-Tools allowlist → createMcpServer → mcp:server:created → transport
 ```
 
 ### `mcp:config:resolved` — mutate tools/resources/prompts per request
 
-Fires after dynamic resolvers and `enabled(event)` guards, before the per-request `McpServer` is built. Mutate `ctx.config` in place.
+Fires after dynamic resolvers and `enabled(event)` guards, before the `X-MCP-Tools` allowlist and the per-request `McpServer` is built. Mutate `ctx.config` in place.
 
 ```typescript [server/plugins/mcp-filter.ts]
 export default defineNitroPlugin((nitroApp) => {
@@ -979,7 +981,7 @@ export default defineNuxtConfig({
 
 | Hook | Fires |
 | --- | --- |
-| `mcp:config:resolved` | Per request, after dynamic resolvers — mutate `config.tools / resources / prompts / instructions / icons / name`. |
+| `mcp:config:resolved` | Per request, after dynamic resolvers — mutate `config.tools / resources / prompts / instructions / icons / name`. `X-MCP-Tools` is applied after this hook. |
 | `mcp:server:created` | Per request, after every definition is registered — call `server.registerTool(...)`, `getSdkServer(server).setRequestHandler(...)`, etc. |
 
 ### Debug

--- a/apps/docs/skills/manage-mcp/references/handlers.md
+++ b/apps/docs/skills/manage-mcp/references/handlers.md
@@ -79,6 +79,8 @@ export default defineMcpHandler({
 
 `getMcpTools`, `getMcpResources`, `getMcpPrompts` return **raw** definitions (with handlers and Zod schemas intact) — exactly what `defineMcpHandler` expects.
 
+Clients can subset the catalog per connection with `X-MCP-Tools` (comma-separated names matching `tools/list`). Unknown names return HTTP 400. Applied after custom `tools:` callbacks, `enabled()`, and `mcp:config:resolved`. No custom handler required.
+
 ## All `defineMcpHandler` Options
 
 ```typescript

--- a/apps/docs/skills/manage-mcp/references/tools.md
+++ b/apps/docs/skills/manage-mcp/references/tools.md
@@ -253,3 +253,4 @@ Requires `mcp.sessions: true` in `nuxt.config.ts`.
 - [Annotations & input examples](https://mcp-toolkit.nuxt.dev/tools/annotations)
 - [Errors & response caching](https://mcp-toolkit.nuxt.dev/tools/errors-caching)
 - [Groups, files & dynamic registration](https://mcp-toolkit.nuxt.dev/tools/groups-organization)
+- [Limit available tools (`X-MCP-Tools`)](https://mcp-toolkit.nuxt.dev/getting-started/connection#limit-available-tools)

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/filter-tools-header.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/filter-tools-header.ts
@@ -1,0 +1,44 @@
+import { enrichNameTitle } from './definitions/utils'
+
+type NamedTool = {
+  name?: string
+  title?: string
+  _meta?: Record<string, unknown>
+}
+
+/**
+ * Parse the `X-MCP-Tools` header. `undefined` means the header is absent
+ * (no filter). An empty or whitespace-only value is an empty allowlist.
+ */
+export function parseMcpToolsHeader(value: string | undefined): Set<string> | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  return new Set(value.split(',').map(name => name.trim()).filter(Boolean))
+}
+
+/**
+ * Keep tools whose resolved `tools/list` name is in `requested`.
+ * Names are resolved the same way as registration (`enrichNameTitle`),
+ * including filename-generated kebab-case.
+ */
+export function filterToolsByRequestedNames<T extends NamedTool>(
+  tools: readonly T[],
+  requested: Set<string>,
+): { tools: T[], unknownNames: string[] } {
+  const resolved = tools.map((tool) => {
+    const { name } = enrichNameTitle({
+      name: tool.name,
+      title: tool.title,
+      _meta: tool._meta,
+      type: 'tool',
+    })
+    return { tool, name }
+  })
+  const known = new Set(resolved.map(entry => entry.name))
+  const unknownNames = [...requested].filter(name => !known.has(name))
+  return {
+    tools: resolved.filter(entry => requested.has(entry.name)).map(entry => entry.tool),
+    unknownNames,
+  }
+}

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/utils.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/utils.ts
@@ -1,5 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { eventHandler, readBody, sendRedirect } from 'h3'
+import { createError, eventHandler, readBody, sendRedirect } from 'h3'
 import type { H3Event } from 'h3'
 import { useNitroApp } from 'nitropack/runtime'
 import { consola } from 'consola'
@@ -12,6 +12,7 @@ import type { McpToolDefinition, McpToolDefinitionListItem } from './definitions
 import { registerToolFromDefinition } from './definitions/tools'
 import type { CodeModeOptions } from './codemode'
 import { getHeader, getRequestMethod } from './compat'
+import { filterToolsByRequestedNames, parseMcpToolsHeader } from './filter-tools-header'
 import { getEvlogLogger } from './internals'
 import { trackLoggingLevel } from './notifications'
 import handleMcpRequest from '#nuxt-mcp-toolkit/transport.mjs'
@@ -252,6 +253,22 @@ async function tagEvlogContext(event: H3Event, route: string) {
   log.set({ mcp })
 }
 
+function applyMcpToolsHeader(config: McpResolvedConfig, event: H3Event): void {
+  const requested = parseMcpToolsHeader(getHeader(event, 'x-mcp-tools'))
+  if (!requested) {
+    return
+  }
+
+  const { tools, unknownNames } = filterToolsByRequestedNames(config.tools, requested)
+  if (unknownNames.length) {
+    throw createError({
+      statusCode: 400,
+      message: `Unknown MCP tool${unknownNames.length > 1 ? 's' : ''}: ${unknownNames.join(', ')}`,
+    })
+  }
+  config.tools = tools
+}
+
 function asString(value: unknown): string | undefined {
   if (typeof value === 'string') return value
   if (typeof value === 'number') return String(value)
@@ -316,6 +333,7 @@ export function createMcpHandler(config: CreateMcpHandlerConfig) {
       tagAuthContext(event)
       const staticConfig = await resolveDynamicDefinitions(resolvedConfig, event)
       await callMcpHook('mcp:config:resolved', { config: staticConfig, event })
+      applyMcpToolsHeader(staticConfig, event)
       const server = await createMcpServer(staticConfig)
       await callMcpHook('mcp:server:created', { server, event })
       return handleMcpRequest(() => server, event)

--- a/packages/nuxt-mcp-toolkit/test/filter-tools-header.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/filter-tools-header.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { parseMcpToolsHeader, filterToolsByRequestedNames } from '../src/runtime/server/mcp/filter-tools-header'
+
+describe('parseMcpToolsHeader', () => {
+  it('returns undefined when the header is absent', () => {
+    expect(parseMcpToolsHeader(undefined)).toBeUndefined()
+  })
+
+  it('returns an empty set for an empty or whitespace-only value', () => {
+    expect(parseMcpToolsHeader('')).toEqual(new Set())
+    expect(parseMcpToolsHeader('  ')).toEqual(new Set())
+    expect(parseMcpToolsHeader(' , , ')).toEqual(new Set())
+  })
+
+  it('trims, splits, and deduplicates names', () => {
+    expect(parseMcpToolsHeader('search-icons, get-component, search-icons')).toEqual(
+      new Set(['search-icons', 'get-component']),
+    )
+  })
+})
+
+describe('filterToolsByRequestedNames', () => {
+  const tools = [
+    { name: 'search-icons', description: 'a' },
+    { name: 'get-component', description: 'b' },
+    { name: 'get-migration-guide', description: 'c' },
+  ]
+
+  it('returns only the requested tools, preserving original order', () => {
+    const result = filterToolsByRequestedNames(tools, new Set(['get-migration-guide', 'search-icons']))
+    expect(result.unknownNames).toEqual([])
+    expect(result.tools.map(tool => tool.name)).toEqual(['search-icons', 'get-migration-guide'])
+  })
+
+  it('returns an empty list when the allowlist is empty', () => {
+    const result = filterToolsByRequestedNames(tools, new Set())
+    expect(result.unknownNames).toEqual([])
+    expect(result.tools).toEqual([])
+  })
+
+  it('reports unknown names without throwing', () => {
+    const result = filterToolsByRequestedNames(tools, new Set(['search-icons', 'nope', 'also-missing']))
+    expect(result.unknownNames).toEqual(['nope', 'also-missing'])
+  })
+
+  it('matches filename-generated kebab-case names', () => {
+    const unnamed = [
+      { _meta: { filename: 'search-icons.ts' } },
+      { _meta: { filename: 'getComponent.ts' } },
+    ]
+    const result = filterToolsByRequestedNames(unnamed, new Set(['search-icons', 'get-component']))
+    expect(result.unknownNames).toEqual([])
+    expect(result.tools).toEqual(unnamed)
+  })
+
+  it('prefers an explicit name over the filename', () => {
+    const named = [{ name: 'custom-name', _meta: { filename: 'search-icons.ts' } }]
+    const miss = filterToolsByRequestedNames(named, new Set(['search-icons']))
+    expect(miss.unknownNames).toEqual(['search-icons'])
+    const hit = filterToolsByRequestedNames(named, new Set(['custom-name']))
+    expect(hit.unknownNames).toEqual([])
+    expect(hit.tools).toEqual(named)
+  })
+})

--- a/packages/nuxt-mcp-toolkit/test/tools.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/tools.test.ts
@@ -1,7 +1,9 @@
 import { fileURLToPath } from 'node:url'
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { setup, url } from '@nuxt/test-utils/e2e'
-import { setupMcpClient, cleanupMcpTests, getMcpClient } from './helpers/mcp-setup.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { setupMcpClient, cleanupMcpTests, getMcpClient, createMcpUrl } from './helpers/mcp-setup.js'
 
 describe('Tools', async () => {
   await setup({
@@ -177,5 +179,46 @@ describe('Tools', async () => {
     expect(result.isError).toBe(true)
     const content = result.content as Array<{ type: string, text?: string }>
     expect(content[0]?.text).toBe('Something went wrong')
+  })
+
+  it('limits tools/list to names in the X-MCP-Tools header', async () => {
+    const client = new Client({ name: 'header-filter-client', version: '1.0.0' })
+    await client.connect(new StreamableHTTPClientTransport(createMcpUrl(), {
+      requestInit: {
+        headers: { 'X-MCP-Tools': 'test_tool, string_tool' },
+      },
+    }))
+
+    try {
+      const { tools } = await client.listTools()
+      expect(tools.map(tool => tool.name).sort()).toEqual(['string_tool', 'test_tool'])
+    }
+    finally {
+      await client.close()
+    }
+  })
+
+  it('returns HTTP 400 when X-MCP-Tools names an unknown tool', async () => {
+    const response = await fetch(url('/mcp'), {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'X-MCP-Tools': 'does-not-exist',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'header-filter-client', version: '1.0.0' },
+        },
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain('Unknown MCP tool: does-not-exist')
   })
 })


### PR DESCRIPTION
## Summary
- Clients can send `X-MCP-Tools` (comma-separated names matching `tools/list`) to limit which tools this request registers.
- Unknown names return HTTP 400. Absent header leaves the catalog unchanged. Applied after `enabled()` and `mcp:config:resolved`, so no custom `server/mcp/index.ts` is required.
- Matches the header convention already copied into [nuxt/ui#6788](https://github.com/nuxt/ui/pull/6788) and [nuxt.com#2383](https://github.com/nuxt/nuxt.com/pull/2383).

## Test plan
- [ ] Unit tests for parse/filter (absent, empty, whitespace, duplicates, kebab-case filename names, unknown names)
- [ ] E2E: `X-MCP-Tools: test_tool, string_tool` subsets `tools/list`
- [ ] E2E: unknown name returns HTTP 400