### PR TITLE
feat(nitro): honor X-MCP-Tools header to subset the tool catalog

### DIFF
--- a/.changeset/nitro-x-mcp-tools-header.md
+++ b/.changeset/nitro-x-mcp-tools-header.md
@@ -1,0 +1,5 @@
+---
+"nitro-mcp-toolkit": minor
+---
+
+Clients can send an `X-MCP-Tools` header with a comma-separated list of tool names to limit what `tools/list` exposes. Unknown names return HTTP 400. `handler.definitions` stays the full catalog.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,8 @@ Windows is covered by a dedicated `test-windows` CI job that runs this package's
 
 **The SDK does no `Origin` validation of its own, so `createMcpHandler` adds one** (`src/runtime/origin.ts`), checked ahead of `sdk.fetch` in both `handle` and `fetch`. The default accepts a page the app serves to itself on a loopback host and refuses every other origin; requests with no `Origin` — every MCP client proper — are unaffected. The loopback condition is not decoration: `event.url` reads the `Host` header, so a bare same-origin comparison is satisfied by DNS rebinding, where the attacker's own hostname lands in both `Host` and `Origin`. Do not drop it to "simplify" the check. `allow` adds explicit origins on top of the default; a user's own `allow` list does not cost the loopback case.
 
+**`X-MCP-Tools` is the same kind of gate** (`src/runtime/tools-header.ts`): allowlist of tool names, HTTP 400 on unknowns, applied before `sdk.fetch`. `handler.definitions` stays the full catalog.
+
 ### MCP Definitions
 
 Use the helper functions:
@@ -252,7 +254,7 @@ If `name` and `title` are omitted, they are auto-generated from the filename:
 
 ### Client tool allowlist
 
-Clients can send `X-MCP-Tools` (comma-separated names matching `tools/list`) to subset the catalog. Unknown names return HTTP 400. Applied after `enabled()` and `mcp:config:resolved`. No `server/mcp/index.ts` required.
+Clients can send `X-MCP-Tools` (comma-separated names matching `tools/list`) to subset the catalog. Unknown names return HTTP 400. On `@nuxtjs/mcp-toolkit` this runs after `enabled()` and `mcp:config:resolved`. On `nitro-mcp-toolkit` it runs ahead of `sdk.fetch` (same place as origin/auth) and does not change `handler.definitions`.
 
 ### Return Types
 

--- a/packages/nitro-mcp-toolkit/README.md
+++ b/packages/nitro-mcp-toolkit/README.md
@@ -110,6 +110,25 @@ An origin is matched exactly, scheme and port included. Pass `origin: false` to 
 
 The loopback condition is the load-bearing part of the default: `Origin` can only be compared against the request's own origin when the host is a loopback address. Everywhere else the host comes from a header the caller sets, and DNS rebinding — the attack this check exists to stop — sends the attacker's hostname in both, so a bare same-origin comparison always agrees with itself.
 
+### Limit available tools
+
+Clients can send `X-MCP-Tools` with a comma-separated list of tool names to expose only those tools. Names must match `tools/list`. Unknown names return HTTP 400. Omit the header to keep the full catalog. Resources and prompts are unaffected.
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "url": "https://example.com/mcp",
+      "headers": {
+        "X-MCP-Tools": "search-icons, get-component"
+      }
+    }
+  }
+}
+```
+
+`handler.definitions` is the full catalog either way — filter that array yourself for a JSON route; the header only changes what this request's MCP server registers.
+
 ### More than one server
 
 Install the module again. Nitro only dedupes modules given as a path, so each call is its own server, with its own definitions.

--- a/packages/nitro-mcp-toolkit/src/runtime/context.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/context.ts
@@ -48,6 +48,8 @@ interface RequestStore {
   event: H3Event
   era: 'legacy' | 'modern'
   notify: ServerNotifier
+  /** Set when the request sent `X-MCP-Tools`; the factory registers only those tools. */
+  toolAllowlist?: Set<string>
 }
 
 const storage = new AsyncLocalStorage<RequestStore>()
@@ -55,8 +57,20 @@ const storage = new AsyncLocalStorage<RequestStore>()
 /**
  * @internal
  */
-export function runWithRequest<T>(event: H3Event, notify: ServerNotifier, fn: () => T): T {
-  return storage.run({ event, era: 'modern', notify }, fn)
+export function runWithRequest<T>(
+  event: H3Event,
+  notify: ServerNotifier,
+  fn: () => T,
+  toolAllowlist?: Set<string>,
+): T {
+  return storage.run({ event, era: 'modern', notify, toolAllowlist }, fn)
+}
+
+/**
+ * @internal
+ */
+export function getToolAllowlist(): Set<string> | undefined {
+  return storage.getStore()?.toolAllowlist
 }
 
 /**

--- a/packages/nitro-mcp-toolkit/src/runtime/handler.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/handler.ts
@@ -1,9 +1,15 @@
 import { createMcpHandler as createSdkHandler, McpServer } from '@modelcontextprotocol/server'
 import { H3Event } from 'h3'
 import { buildAuthGate } from './auth.ts'
-import { runWithRequest, setEra } from './context.ts'
+import { getToolAllowlist, runWithRequest, setEra } from './context.ts'
 import { forbiddenOriginResponse, isOriginAllowed } from './origin.ts'
+import {
+  filterRegistrationsByToolAllowlist,
+  parseMcpToolsHeader,
+  unknownToolsResponse,
+} from './tools-header.ts'
 import { resolveDefinitions, summarize } from './validate.ts'
+import type { McpRegistration } from './validate.ts'
 import type {
   Icon,
   McpHandlerRequestOptions,
@@ -87,8 +93,8 @@ export interface McpHandler {
    */
   fetch: (request: Request, options?: McpHandlerRequestOptions) => Promise<Response>
   /**
-   * Everything this endpoint serves, as plain JSON — a catalog of the same set
-   * every client sees.
+   * Everything this endpoint serves, as plain JSON — the full catalog, not the
+   * per-request `X-MCP-Tools` subset.
    *
    * @example
    * ```ts
@@ -105,6 +111,17 @@ export interface McpHandler {
   notify: ServerNotifier
   bus: ServerEventBus
   close: () => Promise<void>
+}
+
+function gateToolsHeader(
+  registrations: readonly McpRegistration[],
+  event: H3Event,
+): Set<string> | Response | undefined {
+  const requested = parseMcpToolsHeader(event.req.headers.get('x-mcp-tools'))
+  if (!requested) return undefined
+  const { unknownNames } = filterRegistrationsByToolAllowlist(registrations, requested)
+  if (unknownNames.length) return unknownToolsResponse(unknownNames)
+  return requested
 }
 
 /**
@@ -141,7 +158,14 @@ export function createMcpHandler(options: McpHandlerOptions = {}): McpHandler {
         { instructions: options.instructions },
       )
 
-      for (const { definition, identity } of registrations) {
+      const allowlist = getToolAllowlist()
+      const toRegister = allowlist
+        ? registrations.filter(
+            (entry) => entry.definition.kind !== 'tool' || allowlist.has(entry.identity.name),
+          )
+        : registrations
+
+      for (const { definition, identity } of toRegister) {
         definition.register(server, identity)
       }
 
@@ -164,7 +188,10 @@ export function createMcpHandler(options: McpHandlerOptions = {}): McpHandler {
     const denied = await authGate?.(event)
     if (denied) return denied
 
-    return runWithRequest(event, sdk.notify, () => sdk.fetch(request, requestOptions))
+    const toolsHeader = gateToolsHeader(registrations, event)
+    if (toolsHeader instanceof Response) return toolsHeader
+
+    return runWithRequest(event, sdk.notify, () => sdk.fetch(request, requestOptions), toolsHeader)
   }
 
   const handle = async (event: H3Event): Promise<Response> => {
@@ -173,7 +200,10 @@ export function createMcpHandler(options: McpHandlerOptions = {}): McpHandler {
     const denied = await authGate?.(event)
     if (denied) return denied
 
-    return runWithRequest(event, sdk.notify, () => sdk.fetch(event.req))
+    const toolsHeader = gateToolsHeader(registrations, event)
+    if (toolsHeader instanceof Response) return toolsHeader
+
+    return runWithRequest(event, sdk.notify, () => sdk.fetch(event.req), toolsHeader)
   }
 
   return Object.assign(handle, {

--- a/packages/nitro-mcp-toolkit/src/runtime/tools-header.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/tools-header.ts
@@ -1,0 +1,58 @@
+type NamedRegistration = {
+  definition: { kind: string }
+  identity: { name: string }
+}
+
+/**
+ * Parse the `X-MCP-Tools` header. `undefined` means the header is absent
+ * (no filter). An empty or whitespace-only value is an empty allowlist.
+ *
+ * @internal
+ */
+export function parseMcpToolsHeader(value: string | null | undefined): Set<string> | undefined {
+  if (value == null) {
+    return undefined
+  }
+  return new Set(
+    value
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean),
+  )
+}
+
+/**
+ * Keep tools whose registered name is in `requested`. Resources and prompts
+ * are untouched. Unknown names are reported so the handler can 400 before
+ * the protocol layer starts.
+ *
+ * @internal
+ */
+export function filterRegistrationsByToolAllowlist<T extends NamedRegistration>(
+  registrations: readonly T[],
+  requested: Set<string>,
+): { registrations: T[]; unknownNames: string[] } {
+  const toolNames = new Set(
+    registrations
+      .filter((entry) => entry.definition.kind === 'tool')
+      .map((entry) => entry.identity.name),
+  )
+  const unknownNames = [...requested].filter((name) => !toolNames.has(name))
+  return {
+    registrations: registrations.filter(
+      (entry) => entry.definition.kind !== 'tool' || requested.has(entry.identity.name),
+    ),
+    unknownNames,
+  }
+}
+
+/** @internal */
+export function unknownToolsResponse(unknownNames: string[]): Response {
+  return new Response(
+    JSON.stringify({
+      statusCode: 400,
+      message: `Unknown MCP tool${unknownNames.length > 1 ? 's' : ''}: ${unknownNames.join(', ')}`,
+    }),
+    { status: 400, headers: { 'content-type': 'application/json' } },
+  )
+}

--- a/packages/nitro-mcp-toolkit/test/tools-header.test.ts
+++ b/packages/nitro-mcp-toolkit/test/tools-header.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createMcpHandler,
+  defineMcpPrompt,
+  defineMcpResource,
+  defineMcpTool,
+} from '../src/runtime/index.ts'
+import {
+  filterRegistrationsByToolAllowlist,
+  parseMcpToolsHeader,
+} from '../src/runtime/tools-header.ts'
+import { createMcpTestClient } from '../src/testing/index.ts'
+
+function handler() {
+  return createMcpHandler({
+    tools: [
+      defineMcpTool({ name: 'search-icons', handler: () => 'icons' }),
+      defineMcpTool({ name: 'get-component', handler: () => 'component' }),
+      defineMcpTool({ name: 'get-migration-guide', handler: () => 'guide' }),
+    ],
+    resources: [
+      defineMcpResource({ name: 'readme', uri: 'docs://readme', handler: () => 'Readme' }),
+    ],
+    prompts: [defineMcpPrompt({ name: 'review', handler: () => 'ok' })],
+  })
+}
+
+function withToolsHeader(value: string | undefined) {
+  const mcp = handler()
+  return createMcpTestClient({
+    fetch: (request, options) => {
+      const headers = new Headers(request.headers)
+      if (value !== undefined) headers.set('x-mcp-tools', value)
+      return mcp.fetch(new Request(request, { headers }), options)
+    },
+  })
+}
+
+describe('parseMcpToolsHeader', () => {
+  it('returns undefined when the header is absent', () => {
+    expect(parseMcpToolsHeader(undefined)).toBeUndefined()
+    expect(parseMcpToolsHeader(null)).toBeUndefined()
+  })
+
+  it('returns an empty set for an empty or whitespace-only value', () => {
+    expect(parseMcpToolsHeader('')).toEqual(new Set())
+    expect(parseMcpToolsHeader('  ')).toEqual(new Set())
+    expect(parseMcpToolsHeader(' , , ')).toEqual(new Set())
+  })
+
+  it('trims, splits, and deduplicates names', () => {
+    expect(parseMcpToolsHeader('search-icons, get-component, search-icons')).toEqual(
+      new Set(['search-icons', 'get-component']),
+    )
+  })
+})
+
+describe('filterRegistrationsByToolAllowlist', () => {
+  const registrations = [
+    { definition: { kind: 'tool' }, identity: { name: 'search-icons' } },
+    { definition: { kind: 'tool' }, identity: { name: 'get-component' } },
+    { definition: { kind: 'resource' }, identity: { name: 'readme' } },
+  ]
+
+  it('keeps requested tools and every non-tool', () => {
+    const result = filterRegistrationsByToolAllowlist(registrations, new Set(['search-icons']))
+    expect(result.unknownNames).toEqual([])
+    expect(result.registrations.map((entry) => entry.identity.name)).toEqual([
+      'search-icons',
+      'readme',
+    ])
+  })
+
+  it('reports unknown names', () => {
+    const result = filterRegistrationsByToolAllowlist(registrations, new Set(['nope']))
+    expect(result.unknownNames).toEqual(['nope'])
+  })
+})
+
+describe('X-MCP-Tools', () => {
+  it('leaves the catalog alone when the header is absent', async () => {
+    await using client = await withToolsHeader(undefined)
+    const { tools } = await client.listTools()
+    expect(tools.map((tool) => tool.name).sort()).toEqual([
+      'get-component',
+      'get-migration-guide',
+      'search-icons',
+    ])
+  })
+
+  it('limits tools/list to the requested names', async () => {
+    await using client = await withToolsHeader('search-icons, get-component')
+    const { tools } = await client.listTools()
+    expect(tools.map((tool) => tool.name).sort()).toEqual(['get-component', 'search-icons'])
+  })
+
+  it('still serves resources and prompts when tools are subset', async () => {
+    await using client = await withToolsHeader('search-icons')
+    const [{ resources }, { prompts }] = await Promise.all([
+      client.listResources(),
+      client.listPrompts(),
+    ])
+    expect(resources.map((resource) => resource.name)).toEqual(['readme'])
+    expect(prompts.map((prompt) => prompt.name)).toEqual(['review'])
+  })
+
+  it('exposes no tools when the allowlist is empty', async () => {
+    await using client = await withToolsHeader('  ')
+    const { tools } = await client.listTools()
+    expect(tools).toEqual([])
+  })
+
+  it('does not change handler.definitions', () => {
+    expect(
+      handler()
+        .definitions.filter((definition) => definition.kind === 'tool')
+        .map((definition) => definition.name),
+    ).toEqual(['search-icons', 'get-component', 'get-migration-guide'])
+  })
+
+  it('returns HTTP 400 when a name is unknown', async () => {
+    const response = await handler().fetch(
+      new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          'x-mcp-tools': 'does-not-exist',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain('Unknown MCP tool: does-not-exist')
+  })
+})


### PR DESCRIPTION
## Summary
- Stacked on #319. Same `X-MCP-Tools` allowlist for `nitro-mcp-toolkit`: comma-separated names, HTTP 400 on unknowns, resources and prompts untouched.
- Applied ahead of `sdk.fetch` (same place as origin/auth). `handler.definitions` stays the full catalog.
- Parse/filter is duplicated rather than shared with the Nuxt module — the two packages do not share a runtime.

## Test plan
- [ ] Unit tests for parse/filter
- [ ] `tools/list` subsets to requested names; resources and prompts still listed
- [ ] Empty allowlist exposes no tools
- [ ] Unknown name returns HTTP 400
- [ ] `handler.definitions` is unchanged