### PR TITLE
fix(module): unbreak DevTools MCP Inspector launch

### DIFF
--- a/.changeset/mcp-inspector-npx-registry.md
+++ b/.changeset/mcp-inspector-npx-registry.md
@@ -1,0 +1,7 @@
+---
+"@nuxtjs/mcp-toolkit": patch
+---
+
+The DevTools MCP Inspector launch always fetches `@modelcontextprotocol/inspector` from registry.npmjs.org, so a private npmrc can no longer 401 the download. Override with `MCP_INSPECTOR_REGISTRY` if you need a mirror.
+
+The inspector now opens in a new browser tab instead of an iframe inside DevTools — the official UI is a full-page app and does not fit that panel. The MCP URL uses `localhost` so the inspector can reach Nuxt on either IPv4 or IPv6 loopback.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,7 +415,7 @@ This module uses `@modelcontextprotocol/sdk` version 1.23.0+. When referencing S
 
 ### MCP Inspector
 
-The module includes a built-in inspector in Nuxt DevTools for debugging MCP definitions. Access it via the DevTools panel when running in development mode.
+The module includes a built-in inspector in Nuxt DevTools for debugging MCP definitions. Access it via the DevTools **MCP Inspector** tab when running in development mode; it opens in a new browser tab.
 
 ## Agent Skills
 

--- a/apps/docs/content/1.getting-started/4.inspector.md
+++ b/apps/docs/content/1.getting-started/4.inspector.md
@@ -23,11 +23,11 @@ The module includes a built-in integration with the [MCP Inspector](https://gith
    })
    ```
 
-2. **Launch** - Open Nuxt DevTools and navigate to the **MCP Inspector** tab in the **Server** section, then click **Launch Inspector**.
+2. **Launch** - Open Nuxt DevTools and navigate to the **MCP Inspector** tab in the **Server** section, then click **Launch Inspector**. The official inspector is a full-page app, so it opens in a **new browser tab** rather than inside the DevTools panel.
 
 3. **Test** - Use the inspector to browse tools, resources, and prompts, test them with custom parameters, and view request/response history.
 
-The inspector automatically connects to your MCP server endpoint with the correct configuration - no setup needed.
+The inspector automatically connects to your MCP server endpoint with the correct configuration - no setup needed. After launch, the DevTools tab keeps an **Open Inspector** link if you closed the window.
 
 ## Why use it?
 
@@ -62,5 +62,7 @@ CLIENT_PORT=8080 SERVER_PORT=9000 bun dev
 ```
 
 ::
+
+Launch always downloads `@modelcontextprotocol/inspector` from `https://registry.npmjs.org`, so a private npm registry in your user `.npmrc` cannot 401 the install. Override with `MCP_INSPECTOR_REGISTRY` if you need a mirror.
 
 For advanced configuration options, see the [MCP Inspector documentation](https://github.com/modelcontextprotocol/inspector).

--- a/apps/docs/skills/manage-mcp/SKILL.md
+++ b/apps/docs/skills/manage-mcp/SKILL.md
@@ -83,7 +83,7 @@ app/mcp/                   # Optional: MCP Apps (interactive Vue widgets)
 
 1. Start the dev server: `pnpm dev`
 2. Hit the endpoint: `curl http://localhost:3000/mcp` (responds to MCP JSON-RPC)
-3. Open Nuxt DevTools (Shift+Alt+D) → **MCP** tab — bundled MCP Inspector for live testing.
+3. Open Nuxt DevTools (Shift+Alt+D) → **MCP Inspector** tab → Launch Inspector (opens in a new browser tab).
 
 ---
 
@@ -986,7 +986,7 @@ export default defineNuxtConfig({
 
 ### Debug
 
-- **DevTools**: Shift+Alt+D → MCP tab (bundled MCP Inspector).
+- **DevTools**: Shift+Alt+D → MCP Inspector tab → Launch Inspector (opens in a new browser tab).
 - **CLI Inspector**: `npx @modelcontextprotocol/inspector http://localhost:3000/mcp`
 - **curl smoke test**: `curl -X POST … -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`
 

--- a/apps/docs/skills/manage-mcp/references/apps.md
+++ b/apps/docs/skills/manage-mcp/references/apps.md
@@ -245,7 +245,7 @@ Type-only references are stripped from the browser bundle by esbuild — nothing
 
 ### Local dev
 
-Run `pnpm dev` and connect Cursor / Claude / ChatGPT to `http://localhost:3000/mcp` (or your custom route). The DevTools MCP Inspector also previews each app inline.
+Run `pnpm dev` and connect Cursor / Claude / ChatGPT to `http://localhost:3000/mcp` (or your custom route). The DevTools MCP Inspector also opens in a new tab to call each app's tool.
 
 ### Production
 

--- a/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/devtools/index.ts
+++ b/packages/nuxt-mcp-toolkit/src/runtime/server/mcp/devtools/index.ts
@@ -25,6 +25,53 @@ const ERROR_PATTERNS = [
   /port \d+ is already in use/i,
 ]
 
+const NPMJS_REGISTRY = 'https://registry.npmjs.org'
+
+export function inspectorNpxSpec(
+  mcpServerUrl: string,
+  processEnv: NodeJS.ProcessEnv = process.env,
+): { command: string, args: string[], env: NodeJS.ProcessEnv } {
+  const registry = processEnv.MCP_INSPECTOR_REGISTRY || NPMJS_REGISTRY
+  return {
+    command: 'npx',
+    args: [
+      '--registry',
+      registry,
+      '-y',
+      '@modelcontextprotocol/inspector',
+      '--transport',
+      'http',
+      '--server-url',
+      mcpServerUrl,
+    ],
+    env: {
+      ...processEnv,
+      npm_config_registry: registry,
+      NPM_CONFIG_REGISTRY: registry,
+    },
+  }
+}
+
+/**
+ * MCP URL handed to the inspector. Loopback hosts become `localhost` so the
+ * inspector's Node fetch can hit whichever stack Nuxt bound (`::1` or
+ * `127.0.0.1`). Rewriting to `127.0.0.1` breaks the default IPv6 listen.
+ */
+export function inspectorMcpUrl(
+  devServerUrl: string | undefined,
+  route: string,
+  https: boolean,
+  port: number,
+): string {
+  const protocol = https ? 'https' : 'http'
+  const parsed = new URL(devServerUrl || `${protocol}://localhost:${port}`)
+  if (parsed.hostname === '::1' || parsed.hostname === '[::1]' || parsed.hostname === '127.0.0.1') {
+    parsed.hostname = 'localhost'
+  }
+  const origin = `${parsed.origin}${parsed.pathname}`.replace(/\/$/, '')
+  return `${origin}${route}`
+}
+
 let inspectorProcess: ChildProcess | null = null
 let inspectorUrl: string | null = null
 let isReady = false
@@ -162,15 +209,13 @@ async function launchMcpInspector(nuxt: Nuxt, options: ModuleOptions): Promise<v
     return
   }
 
-  const devServerUrl = nuxt.options.devServer?.url
-  let mcpServerUrl: string
-  if (devServerUrl) {
-    mcpServerUrl = `${devServerUrl.replace(/\/$/, '')}${options.route || '/mcp'}`
-  }
-  else {
-    const protocol = nuxt.options.devServer?.https ? 'https' : 'http'
-    mcpServerUrl = `${protocol}://localhost:${nuxt.options.devServer?.port || 3000}${options.route || '/mcp'}`
-  }
+  const route = options.route || '/mcp'
+  const mcpServerUrl = inspectorMcpUrl(
+    nuxt.options.devServer?.url,
+    route,
+    Boolean(nuxt.options.devServer?.https),
+    nuxt.options.devServer?.port || 3000,
+  )
   const inspectorClientPort = getInspectorClientPort()
   const inspectorServerPort = getInspectorServerPort()
   const inspectorBaseUrl = buildInspectorBaseUrl(inspectorClientPort)
@@ -178,21 +223,15 @@ async function launchMcpInspector(nuxt: Nuxt, options: ModuleOptions): Promise<v
   log.info('🚀 Launching MCP Inspector...')
 
   try {
-    const env = {
-      ...globalThis.process.env,
-      MCP_AUTO_OPEN_ENABLED: 'false',
-      CLIENT_PORT: String(inspectorClientPort),
-      SERVER_PORT: String(inspectorServerPort),
-    }
-
-    inspectorProcess = spawn('npx', [
-      '-y',
-      '@modelcontextprotocol/inspector',
-      '--transport', 'http',
-      '--server-url', mcpServerUrl,
-    ], {
+    const spec = inspectorNpxSpec(mcpServerUrl)
+    inspectorProcess = spawn(spec.command, spec.args, {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env,
+      env: {
+        ...spec.env,
+        MCP_AUTO_OPEN_ENABLED: 'true',
+        CLIENT_PORT: String(inspectorClientPort),
+        SERVER_PORT: String(inspectorServerPort),
+      },
       shell: globalThis.process.platform === 'win32',
     })
 
@@ -405,16 +444,15 @@ export function addDevToolsCustomTabs(nuxt: Nuxt, options: ModuleOptions) {
       name: 'mcp-inspector',
       title: 'MCP Inspector',
       icon: 'i-lucide-circuit-board',
-      view: isReady && inspectorUrl
-        ? {
-            type: 'iframe',
-            src: inspectorUrl,
-          }
-        : {
-            type: 'launch',
-            description: 'Launch MCP Inspector to test/debug your MCP server',
-            actions: [
-              {
+      view: {
+        type: 'launch',
+        description: isReady && inspectorUrl
+          ? 'The official inspector is a full-page app, so it opens in a new tab rather than inside this panel.'
+          : 'Launch MCP Inspector to test/debug your MCP server',
+        actions: [
+          ...(isReady && inspectorUrl
+            ? [{ label: 'Open Inspector', src: inspectorUrl }]
+            : [{
                 label: promise ? 'Starting...' : 'Launch Inspector',
                 pending: !!promise,
                 handle() {
@@ -425,18 +463,18 @@ export function addDevToolsCustomTabs(nuxt: Nuxt, options: ModuleOptions) {
                   })
                   return promise
                 },
-              },
-              ...(inspectorProcess
-                ? [{
-                    label: 'Stop Inspector',
-                    handle() {
-                      stopMcpInspector()
-                      promise = null
-                    },
-                  }]
-                : []),
-            ],
-          },
+              }]),
+          ...(inspectorProcess
+            ? [{
+                label: 'Stop Inspector',
+                handle() {
+                  stopMcpInspector()
+                  promise = null
+                },
+              }]
+            : []),
+        ],
+      },
     })
   })
 

--- a/packages/nuxt-mcp-toolkit/test/inspector-npx.test.ts
+++ b/packages/nuxt-mcp-toolkit/test/inspector-npx.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { inspectorMcpUrl, inspectorNpxSpec } from '../src/runtime/server/mcp/devtools'
+
+const NPMJS = 'https://registry.npmjs.org'
+
+describe('inspectorNpxSpec', () => {
+  it('fetches the inspector from npmjs.org by default', () => {
+    const spec = inspectorNpxSpec('http://localhost:3000/mcp', { PATH: '/usr/bin' })
+
+    expect(spec.command).toBe('npx')
+    expect(spec.args).toEqual([
+      '--registry',
+      NPMJS,
+      '-y',
+      '@modelcontextprotocol/inspector',
+      '--transport',
+      'http',
+      '--server-url',
+      'http://localhost:3000/mcp',
+    ])
+    expect(spec.env.npm_config_registry).toBe(NPMJS)
+    expect(spec.env.NPM_CONFIG_REGISTRY).toBe(NPMJS)
+  })
+
+  it('ignores an inherited npm_config_registry (private npmrc must not 401 the download)', () => {
+    const spec = inspectorNpxSpec('http://localhost:3000/mcp', {
+      npm_config_registry: 'https://registry.k8s.vercel-security.com/npm/',
+      NPM_CONFIG_REGISTRY: 'https://registry.k8s.vercel-security.com/npm/',
+    })
+
+    expect(spec.args[1]).toBe(NPMJS)
+    expect(spec.env.npm_config_registry).toBe(NPMJS)
+    expect(spec.env.NPM_CONFIG_REGISTRY).toBe(NPMJS)
+  })
+
+  it('uses MCP_INSPECTOR_REGISTRY when set', () => {
+    const mirror = 'https://npm.example.internal'
+    const spec = inspectorNpxSpec('http://localhost:3000/mcp', {
+      MCP_INSPECTOR_REGISTRY: mirror,
+      npm_config_registry: 'https://registry.k8s.vercel-security.com/npm/',
+    })
+
+    expect(spec.args[1]).toBe(mirror)
+    expect(spec.env.npm_config_registry).toBe(mirror)
+    expect(spec.env.NPM_CONFIG_REGISTRY).toBe(mirror)
+  })
+})
+
+describe('inspectorMcpUrl', () => {
+  it('rewrites IPv6 and IPv4 loopback to localhost', () => {
+    expect(inspectorMcpUrl('http://[::1]:3000/', '/mcp', false, 3000)).toBe('http://localhost:3000/mcp')
+    expect(inspectorMcpUrl('http://127.0.0.1:3000/', '/mcp', false, 3000)).toBe('http://localhost:3000/mcp')
+  })
+
+  it('keeps an existing localhost origin', () => {
+    expect(inspectorMcpUrl('http://localhost:3000/', '/mcp', false, 3000)).toBe('http://localhost:3000/mcp')
+  })
+
+  it('falls back to localhost when Nuxt has no devServer.url', () => {
+    expect(inspectorMcpUrl(undefined, '/mcp', false, 3000)).toBe('http://localhost:3000/mcp')
+  })
+
+  it('does not rewrite a non-loopback host', () => {
+    expect(inspectorMcpUrl('http://example.test:3000/', '/mcp', false, 3000)).toBe('http://example.test:3000/mcp')
+  })
+})


### PR DESCRIPTION
Private npmrc 401s, the iframe clips the official UI, and rewriting the MCP URL to 127.0.0.1 misses Nuxt's IPv6 listen.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
Here are the available types and scopes:


### Types
- breaking (fix or feature that would cause existing functionality to change) 💥
- feat (a non-breaking change that adds functionality) ✨
- fix (a non-breaking change that fixes an issue) 🐞
- build (changes that affect the build system or external dependencies) 🏗
- ci (changes to our CI configuration files and scripts) 🚀
- docs (updates to the documentation or readme) 📖
- enhancement (improving an existing functionality) 🌈
- chore (updates to the build process or auxiliary tools and libraries) 📦
- perf (a code change that improves performance) ⚡️
- style (changes that do not affect the meaning of the code) 💅
- test (adding or updating tests) 🧪
- refactor (a code change that neither fixes a bug nor adds a feature) 🛠
- revert (reverts a previous commit) 🔄

### Scopes
- deps (dependencies of the project)
- docs (the documentation)
- module (@nuxtjs/mcp-toolkit)
- nitro (nitro-mcp-toolkit)
- playground (the playground)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
