### PR TITLE
fix(nitro): support Valibot schemas

### DIFF
--- a/.changeset/tame-cars-occur.md
+++ b/.changeset/tame-cars-occur.md
@@ -1,0 +1,5 @@
+---
+"nitro-mcp-toolkit": patch
+---
+
+Advertise and validate Valibot schemas, including schemas with trim actions, for tool inputs, tool outputs, and prompt arguments.

--- a/packages/nitro-mcp-toolkit/package.json
+++ b/packages/nitro-mcp-toolkit/package.json
@@ -68,6 +68,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.5",
     "@modelcontextprotocol/client": "2.0.0",
+    "@valibot/to-json-schema": "^1.7.1",
     "@vitest/coverage-v8": "^4.1.10",
     "h3": "2.0.1-rc.27",
     "nitro": "3.0.260610-beta",
@@ -76,6 +77,7 @@
     "oxlint": "^1.77.0",
     "publint": "^0.3.23",
     "typescript": "~6.0.3",
+    "valibot": "^1.4.2",
     "vitest": "^4.1.10",
     "zod": "^4.2.0"
   },

--- a/packages/nitro-mcp-toolkit/src/runtime/prompt.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/prompt.ts
@@ -1,4 +1,5 @@
 import { attachNotify } from './context.ts'
+import { resolveSchema } from './schema.ts'
 import { resolveMeta } from './validate.ts'
 import type { H3Event } from 'h3'
 import type { GetPromptResult, Icon, PromptArgument, StandardTypedV1 } from 'h3-mcp'
@@ -98,7 +99,7 @@ export function defineMcpPrompt(
         const { inputSchema, handler } = definition
         into.prompts.push({
           ...advertised,
-          arguments: inputSchema,
+          arguments: resolveSchema(inputSchema),
           handler: async (args: StandardTypedV1.InferOutput<Schema>, event: H3Event) =>
             toPromptResult(await handler(args, attachNotify(event, notify))),
         })

--- a/packages/nitro-mcp-toolkit/src/runtime/schema.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/schema.ts
@@ -2,19 +2,16 @@ import { toStandardJsonSchema } from '@valibot/to-json-schema'
 import type { StandardJSONSchemaV1, StandardTypedV1 } from 'h3-mcp'
 import type { GenericSchema } from 'valibot'
 
-function hasJsonSchema(schema: StandardTypedV1): boolean {
-  const standard = schema['~standard']
-  if (!('jsonSchema' in standard)) return false
-  return standard.jsonSchema !== null && typeof standard.jsonSchema === 'object'
-}
-
 function isValibotSchema(schema: StandardTypedV1): schema is GenericSchema {
   return schema['~standard'].vendor === 'valibot' && 'async' in schema && schema.async === false
 }
 
-function withTrimIgnored(converter: StandardJSONSchemaV1['~standard']['jsonSchema']) {
+export function resolveSchema(schema: StandardTypedV1 | undefined): StandardTypedV1 | undefined {
+  if (!schema || !isValibotSchema(schema)) return schema
+
+  const standard = toStandardJsonSchema(schema)['~standard']
   const convert = (method: 'input' | 'output') => (options: StandardJSONSchemaV1.Options) =>
-    converter[method]({
+    standard.jsonSchema[method]({
       ...options,
       libraryOptions: {
         ...options.libraryOptions,
@@ -22,20 +19,13 @@ function withTrimIgnored(converter: StandardJSONSchemaV1['~standard']['jsonSchem
       },
     })
 
-  return {
-    input: convert('input'),
-    output: convert('output'),
-  }
-}
-
-export function resolveSchema(schema: StandardTypedV1 | undefined): StandardTypedV1 | undefined {
-  if (!schema || !isValibotSchema(schema) || hasJsonSchema(schema)) return schema
-
-  const resolved = toStandardJsonSchema(schema)
   const converted: StandardJSONSchemaV1 = {
     '~standard': {
-      ...resolved['~standard'],
-      jsonSchema: withTrimIgnored(resolved['~standard'].jsonSchema),
+      ...standard,
+      jsonSchema: {
+        input: convert('input'),
+        output: convert('output'),
+      },
     },
   }
   return converted

--- a/packages/nitro-mcp-toolkit/src/runtime/schema.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/schema.ts
@@ -1,0 +1,42 @@
+import { toStandardJsonSchema } from '@valibot/to-json-schema'
+import type { StandardJSONSchemaV1, StandardTypedV1 } from 'h3-mcp'
+import type { GenericSchema } from 'valibot'
+
+function hasJsonSchema(schema: StandardTypedV1): boolean {
+  const standard = schema['~standard']
+  if (!('jsonSchema' in standard)) return false
+  return standard.jsonSchema !== null && typeof standard.jsonSchema === 'object'
+}
+
+function isValibotSchema(schema: StandardTypedV1): schema is GenericSchema {
+  return schema['~standard'].vendor === 'valibot' && 'async' in schema && schema.async === false
+}
+
+function withTrimIgnored(converter: StandardJSONSchemaV1['~standard']['jsonSchema']) {
+  const convert = (method: 'input' | 'output') => (options: StandardJSONSchemaV1.Options) =>
+    converter[method]({
+      ...options,
+      libraryOptions: {
+        ...options.libraryOptions,
+        ignoreActions: ['trim'],
+      },
+    })
+
+  return {
+    input: convert('input'),
+    output: convert('output'),
+  }
+}
+
+export function resolveSchema(schema: StandardTypedV1 | undefined): StandardTypedV1 | undefined {
+  if (!schema || !isValibotSchema(schema) || hasJsonSchema(schema)) return schema
+
+  const resolved = toStandardJsonSchema(schema)
+  const converted: StandardJSONSchemaV1 = {
+    '~standard': {
+      ...resolved['~standard'],
+      jsonSchema: withTrimIgnored(resolved['~standard'].jsonSchema),
+    },
+  }
+  return converted
+}

--- a/packages/nitro-mcp-toolkit/src/runtime/tool.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/tool.ts
@@ -1,6 +1,7 @@
 import { McpJsonRpcError } from 'h3-mcp'
 import { attachNotify } from './context.ts'
 import { isInputRequired, toCallToolResult, toErrorResult } from './results.ts'
+import { resolveSchema } from './schema.ts'
 import { resolveMeta } from './validate.ts'
 import type { H3Event } from 'h3'
 import type {
@@ -115,7 +116,7 @@ export function defineMcpTool(
         name: identity.name,
         title: identity.title,
         description,
-        outputSchema,
+        outputSchema: resolveSchema(outputSchema),
         annotations,
         icons,
         _meta: resolveMeta(identity.group, tags),
@@ -125,7 +126,7 @@ export function defineMcpTool(
         const { inputSchema, handler } = definition
         into.tools.push({
           ...advertised,
-          inputSchema,
+          inputSchema: resolveSchema(inputSchema),
           handler: (args: StandardTypedV1.InferOutput<Schema>, event: H3Event) =>
             settle(() => handler(args, attachNotify(event, notify)), hasOutputSchema),
         })

--- a/packages/nitro-mcp-toolkit/test/valibot.test.ts
+++ b/packages/nitro-mcp-toolkit/test/valibot.test.ts
@@ -6,7 +6,7 @@ import { createMcpTestClient } from '../src/testing/index.ts'
 const trimmedString = v.pipe(v.string(), v.trim(), v.minLength(1))
 
 describe('Valibot schemas', () => {
-  it('advertises and validates tool input and output schemas', async () => {
+  it('advertises and validates tool and prompt schemas', async () => {
     const handler = createMcpHandler({
       tools: [
         defineMcpTool({
@@ -19,6 +19,15 @@ describe('Valibot schemas', () => {
           name: 'invalid-output',
           outputSchema: v.object({ greeting: trimmedString }),
           handler: () => ({ greeting: ' ' }),
+        }),
+      ],
+      prompts: [
+        defineMcpPrompt({
+          name: 'review',
+          inputSchema: v.object({
+            path: v.pipe(trimmedString, v.description('File to review')),
+          }),
+          handler: ({ path }) => `Review ${path}.`,
         }),
       ],
     })
@@ -38,8 +47,8 @@ describe('Valibot schemas', () => {
     expect(tools[0]?.inputSchema).not.toHaveProperty('~standard')
     expect(tools[0]?.outputSchema).not.toHaveProperty('~standard')
 
-    const result = await client.callTool({ name: 'greet', arguments: { name: ' Ada ' } })
-    expect(result.structuredContent).toEqual({ greeting: 'Hello Ada' })
+    const toolResult = await client.callTool({ name: 'greet', arguments: { name: ' Ada ' } })
+    expect(toolResult.structuredContent).toEqual({ greeting: 'Hello Ada' })
 
     const invalidInput = await client.callTool({ name: 'greet', arguments: { name: ' ' } })
     expect(invalidInput.isError).toBe(true)
@@ -50,29 +59,17 @@ describe('Valibot schemas', () => {
     await expect(client.callTool({ name: 'invalid-output' })).rejects.toThrow(
       /does not match its outputSchema/,
     )
-  })
-
-  it('advertises and validates prompt arguments', async () => {
-    const handler = createMcpHandler({
-      prompts: [
-        defineMcpPrompt({
-          name: 'review',
-          inputSchema: v.object({
-            path: v.pipe(trimmedString, v.description('File to review')),
-          }),
-          handler: ({ path }) => `Review ${path}.`,
-        }),
-      ],
-    })
-    await using client = await createMcpTestClient(handler)
 
     const { prompts } = await client.listPrompts()
     expect(prompts[0]?.arguments).toEqual([
       { name: 'path', description: 'File to review', required: true },
     ])
 
-    const result = await client.getPrompt({ name: 'review', arguments: { path: ' src/index.ts ' } })
-    expect(result.messages).toEqual([
+    const promptResult = await client.getPrompt({
+      name: 'review',
+      arguments: { path: ' src/index.ts ' },
+    })
+    expect(promptResult.messages).toEqual([
       { role: 'user', content: { type: 'text', text: 'Review src/index.ts.' } },
     ])
 

--- a/packages/nitro-mcp-toolkit/test/valibot.test.ts
+++ b/packages/nitro-mcp-toolkit/test/valibot.test.ts
@@ -1,0 +1,83 @@
+import * as v from 'valibot'
+import { describe, expect, it } from 'vitest'
+import { createMcpHandler, defineMcpPrompt, defineMcpTool } from '../src/runtime/index.ts'
+import { createMcpTestClient } from '../src/testing/index.ts'
+
+const trimmedString = v.pipe(v.string(), v.trim(), v.minLength(1))
+
+describe('Valibot schemas', () => {
+  it('advertises and validates tool input and output schemas', async () => {
+    const handler = createMcpHandler({
+      tools: [
+        defineMcpTool({
+          name: 'greet',
+          inputSchema: v.object({ name: trimmedString }),
+          outputSchema: v.object({ greeting: trimmedString }),
+          handler: ({ name }) => ({ greeting: `Hello ${name}` }),
+        }),
+        defineMcpTool({
+          name: 'invalid-output',
+          outputSchema: v.object({ greeting: trimmedString }),
+          handler: () => ({ greeting: ' ' }),
+        }),
+      ],
+    })
+    await using client = await createMcpTestClient(handler)
+
+    const { tools } = await client.listTools()
+    expect(tools[0]?.inputSchema).toMatchObject({
+      type: 'object',
+      properties: { name: { type: 'string', minLength: 1 } },
+      required: ['name'],
+    })
+    expect(tools[0]?.outputSchema).toMatchObject({
+      type: 'object',
+      properties: { greeting: { type: 'string', minLength: 1 } },
+      required: ['greeting'],
+    })
+    expect(tools[0]?.inputSchema).not.toHaveProperty('~standard')
+    expect(tools[0]?.outputSchema).not.toHaveProperty('~standard')
+
+    const result = await client.callTool({ name: 'greet', arguments: { name: ' Ada ' } })
+    expect(result.structuredContent).toEqual({ greeting: 'Hello Ada' })
+
+    const invalidInput = await client.callTool({ name: 'greet', arguments: { name: ' ' } })
+    expect(invalidInput.isError).toBe(true)
+    expect(invalidInput.content).toMatchObject([
+      { type: 'text', text: expect.stringContaining('Invalid input') },
+    ])
+
+    await expect(client.callTool({ name: 'invalid-output' })).rejects.toThrow(
+      /does not match its outputSchema/,
+    )
+  })
+
+  it('advertises and validates prompt arguments', async () => {
+    const handler = createMcpHandler({
+      prompts: [
+        defineMcpPrompt({
+          name: 'review',
+          inputSchema: v.object({
+            path: v.pipe(trimmedString, v.description('File to review')),
+          }),
+          handler: ({ path }) => `Review ${path}.`,
+        }),
+      ],
+    })
+    await using client = await createMcpTestClient(handler)
+
+    const { prompts } = await client.listPrompts()
+    expect(prompts[0]?.arguments).toEqual([
+      { name: 'path', description: 'File to review', required: true },
+    ])
+
+    const result = await client.getPrompt({ name: 'review', arguments: { path: ' src/index.ts ' } })
+    expect(result.messages).toEqual([
+      { role: 'user', content: { type: 'text', text: 'Review src/index.ts.' } },
+    ])
+
+    await expect(client.getPrompt({ name: 'review', arguments: { path: ' ' } })).rejects.toThrow(
+      /Invalid prompt arguments/,
+    )
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0
+      '@valibot/to-json-schema':
+        specifier: ^1.7.1
+        version: 1.7.1(valibot@1.4.2(typescript@6.0.3))
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
@@ -239,6 +242,9 @@ importers:
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
+      valibot:
+        specifier: ^1.4.2
+        version: 1.4.2(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -4675,6 +4681,11 @@ packages:
 
   '@uploadthing/mime-types@0.3.6':
     resolution: {integrity: sha512-t3tTzgwFV9+1D7lNDYc7Lr7kBwotHaX0ZsvoCGe7xGnXKo9z0jG2Sjl/msll12FeoLj77nyhsxevXyGpQDBvLg==}
+
+  '@valibot/to-json-schema@1.7.1':
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+    peerDependencies:
+      valibot: ^1.4.0
 
   '@vercel/analytics@2.0.1':
     resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
@@ -10317,6 +10328,14 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -16361,6 +16380,10 @@ snapshots:
     optional: true
 
   '@uploadthing/mime-types@0.3.6': {}
+
+  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.4.2(typescript@6.0.3)
 
   '@vercel/analytics@2.0.1(nuxt@4.5.2(5d00c0b0fe088c6496591b7619c62f2f))(react@19.2.8)(vue@3.5.41(typescript@6.0.3))':
     optionalDependencies:
@@ -23842,6 +23865,10 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  valibot@1.4.2(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   validate-npm-package-name@5.0.1: {}
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #313

### 📚 Description

The Nitro v3 package accepts raw Valibot schemas, but they do not expose Standard JSON Schema. This caused `tools/list` to return Valibot's internal schema and left prompt arguments empty.

This wraps raw Valibot schemas with the official converter before they reach `h3-mcp`. It covers tool inputs, tool outputs, and prompt arguments while preserving validation and transforms such as `trim`.

The converter is bundled into `nitro-mcp-toolkit`, so users do not need to install it.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. No change was needed because this restores the documented Valibot support.
