### PR TITLE
feat(nitro): add clerk, okta and workos oauth connectors

### DIFF
--- a/.changeset/nitro-oauth-connectors.md
+++ b/.changeset/nitro-oauth-connectors.md
@@ -1,0 +1,13 @@
+---
+"nitro-mcp-toolkit": minor
+---
+
+Connectors fill in the issuer conventions of three providers, so `oauth` is one call instead of a JWKS URL you looked up by hand. Each returns the same options object `mcp({ oauth })` and `createMcpOAuth` already accept, and each sits on its own subpath — an app that imports none of them never loads them.
+
+```ts
+import { clerk } from 'nitro-mcp-toolkit/oauth/clerk'
+
+mcp({ oauth: clerk({ resource: 'https://api.example.com/mcp' }) })
+```
+
+`clerk` reads `CLERK_PUBLISHABLE_KEY` for the issuer and JWKS, skips audience checks (Clerk puts the OAuth client in `azp`, so use `authorizedParties`), and proxies RFC 8414 metadata from Clerk for clients that only look on the resource origin. `okta` covers custom authorization servers and derives JWKS from the issuer. `workos` covers AuthKit, where `aud` is the client id rather than the MCP URL.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,7 +192,7 @@ The runtime is written against a pinned `h3-mcp` (currently 0.2.0). That release
 
 **`X-MCP-Tools` is the same kind of gate** (`src/runtime/tools-header.ts`): allowlist of tool names, HTTP 400 on unknowns, applied before the engine runs. `handler.definitions` stays the full catalog.
 
-**OAuth** is a generic resource-server: `mcp({ oauth: { resource, authorizationServers, jwt } })` or `createMcpOAuth`. JWT verify, claims on `event.context.oauth`, RFC 9728 metadata mounted. The package does not mint tokens. Opaque tokens still mean `createMcpOAuth({ verify })` in a route file.
+**OAuth** is a generic resource-server: `mcp({ oauth: { resource, authorizationServers, jwt } })` or `createMcpOAuth`. JWT verify, claims on `event.context.oauth`, RFC 9728 metadata mounted. Connectors (`nitro-mcp-toolkit/oauth/clerk`, `/okta`, `/workos`) return that same options object — Clerk infers issuer/JWKS from `CLERK_PUBLISHABLE_KEY` and skips `aud` (client is in `azp`). The package does not mint tokens. Opaque tokens still mean `createMcpOAuth({ verify })` in a route file.
 
 ### MCP Definitions
 

--- a/packages/nitro-mcp-toolkit/README.md
+++ b/packages/nitro-mcp-toolkit/README.md
@@ -427,6 +427,56 @@ This package is the **resource server**, not the authorization server. It does n
 
 `mcp({ oauth })` is the usual path: JWT access tokens, file-based definitions, RFC 9728 metadata mounted for you. Verified claims land on `event.context.oauth`. `iss` defaults to `authorizationServers`, `aud` to `resource`. Pass `jwt.audience: false` only when the issuer does not put this MCP URL in the token.
 
+Connectors live on their own subpaths (`nitro-mcp-toolkit/oauth/clerk`, `/okta`, `/workos`) so an app that uses none of them never loads them. Each returns the same options `createMcpOAuth` accepts.
+
+#### Clerk
+
+```ts
+import { clerk } from 'nitro-mcp-toolkit/oauth/clerk'
+
+mcp({
+  oauth: clerk({ resource: 'https://api.example.com/mcp' }),
+})
+```
+
+Issuer and JWKS come from `CLERK_PUBLISHABLE_KEY` or `NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY`. Audience is not checked (Clerk puts the OAuth client in `azp`); pass `authorizedParties` to allowlist clients. RFC 8414 metadata is proxied from Clerk so older MCP clients that look on the resource origin still discover it.
+
+```ts
+defineMcpTool({
+  name: 'whoami',
+  handler: (event) => event.context.oauth?.sub ?? 'anonymous',
+})
+```
+
+A 401 then answers with `WWW-Authenticate: Bearer realm="mcp", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp"`. Enable CIMD (or DCR only if the client cannot do CIMD) on the Clerk [OAuth applications](https://dashboard.clerk.com/~/oauth-applications) page so clients can register.
+
+#### Okta
+
+Custom authorization servers only (org-server tokens are opaque). JWKS is `{issuer}/v1/keys`. `OKTA_DOMAIN` or `OKTA_ISSUER` fill in what you omit.
+
+```ts
+import { okta } from 'nitro-mcp-toolkit/oauth/okta'
+
+mcp({
+  oauth: okta({
+    resource: 'https://api.example.com/mcp',
+    domain: 'acme.okta.com',
+  }),
+})
+```
+
+#### WorkOS
+
+AuthKit session tokens. JWKS is `/sso/jwks/{clientId}`; `aud` is the client id, not the MCP URL. `clientId` defaults to `WORKOS_CLIENT_ID`.
+
+```ts
+import { workos } from 'nitro-mcp-toolkit/oauth/workos'
+
+mcp({
+  oauth: workos({ resource: 'https://api.example.com/mcp' }),
+})
+```
+
 #### Any other JWT issuer
 
 ```ts

--- a/packages/nitro-mcp-toolkit/build.config.ts
+++ b/packages/nitro-mcp-toolkit/build.config.ts
@@ -11,6 +11,9 @@ export default defineBuildConfig({
       type: 'bundle',
       input: [
         './src/runtime/index.ts',
+        './src/runtime/oauth/clerk.ts',
+        './src/runtime/oauth/okta.ts',
+        './src/runtime/oauth/workos.ts',
         './src/runtime/servers.ts',
         './src/module/index.ts',
         './src/testing/index.ts',

--- a/packages/nitro-mcp-toolkit/package.json
+++ b/packages/nitro-mcp-toolkit/package.json
@@ -31,6 +31,18 @@
       "types": "./dist/runtime/index.d.mts",
       "import": "./dist/runtime/index.mjs"
     },
+    "./oauth/clerk": {
+      "types": "./dist/runtime/oauth/clerk.d.mts",
+      "import": "./dist/runtime/oauth/clerk.mjs"
+    },
+    "./oauth/okta": {
+      "types": "./dist/runtime/oauth/okta.d.mts",
+      "import": "./dist/runtime/oauth/okta.mjs"
+    },
+    "./oauth/workos": {
+      "types": "./dist/runtime/oauth/workos.d.mts",
+      "import": "./dist/runtime/oauth/workos.mjs"
+    },
     "./servers": {
       "types": "./dist/runtime/servers.d.mts",
       "import": "./dist/runtime/servers.mjs"

--- a/packages/nitro-mcp-toolkit/src/module/options.ts
+++ b/packages/nitro-mcp-toolkit/src/module/options.ts
@@ -59,6 +59,9 @@ export interface McpServerOptions {
 /**
  * JWT resource-server config for `mcp()`. JSON-serializable, so it can cross
  * into generated code. Opaque tokens or extra checks still mean a route file.
+ *
+ * Connectors (`nitro-mcp-toolkit/oauth/clerk`, `/okta`, `/workos`) return this
+ * shape — pass their result as `oauth`.
  */
 export type McpModuleOAuthOptions = McpOAuthSetup
 
@@ -96,12 +99,10 @@ export interface McpModuleOptions extends McpServerOptions {
    *
    * @example
    * ```ts
+   * import { clerk } from 'nitro-mcp-toolkit/oauth/clerk'
+   *
    * mcp({
-   *   oauth: {
-   *     resource: 'https://api.example.com/mcp',
-   *     authorizationServers: ['https://auth.example.com'],
-   *     jwt: { jwks: 'https://auth.example.com/.well-known/jwks.json' },
-   *   },
+   *   oauth: clerk({ resource: 'https://api.example.com/mcp' }),
    * })
    * ```
    */

--- a/packages/nitro-mcp-toolkit/src/runtime/oauth/clerk.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/oauth/clerk.ts
@@ -1,0 +1,84 @@
+import { envValue } from './env.ts'
+import type { McpOAuthSetup } from '../oauth.ts'
+
+const KEY_PREFIX = /^pk_(test|live)_/
+const CLERK_SCOPES = ['openid', 'profile', 'email']
+const CLERK_ENV = ['CLERK_PUBLISHABLE_KEY', 'NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY'] as const
+
+export interface ClerkOAuthOptions {
+  /**
+   * This MCP endpoint as a resource identifier.
+   *
+   * @example 'https://api.example.com/mcp'
+   */
+  resource: string
+  /**
+   * Defaults to `CLERK_PUBLISHABLE_KEY` or `NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY`.
+   * Pass it explicitly from a route file on a runtime that has no `process.env`.
+   */
+  publishableKey?: string
+  /**
+   * `azp` values this resource accepts. Omit to accept any OAuth client this
+   * Clerk instance issued.
+   */
+  authorizedParties?: string[]
+  scopesSupported?: string[]
+}
+
+function frontendApiFromPublishableKey(key: string): string {
+  const trimmed = key.trim()
+
+  if (!KEY_PREFIX.test(trimmed)) {
+    throw new Error(
+      '[nitro-mcp-toolkit] `clerk` needs a Clerk publishable key (pk_test_… or pk_live_…).',
+    )
+  }
+
+  let decoded: string
+
+  try {
+    decoded = atob(trimmed.replace(KEY_PREFIX, ''))
+  } catch {
+    throw new Error('[nitro-mcp-toolkit] `clerk` publishable key is not valid base64.')
+  }
+
+  const host = decoded.replace(/\$$/, '')
+
+  if (!host.includes('.')) {
+    throw new Error(
+      '[nitro-mcp-toolkit] `clerk` publishable key did not contain a Frontend API host.',
+    )
+  }
+
+  return host
+}
+
+/**
+ * Clerk's issuer, JWKS, and the `aud` skip Clerk access tokens need (`azp`
+ * holds the OAuth client). RFC 8414 is proxied from the Frontend API so older
+ * MCP clients that look on the resource origin still discover it.
+ */
+export function clerk(options: ClerkOAuthOptions): McpOAuthSetup {
+  const key = options.publishableKey ?? envValue(CLERK_ENV)
+
+  if (!key) {
+    throw new Error(
+      '[nitro-mcp-toolkit] `clerk` needs `publishableKey`, or `CLERK_PUBLISHABLE_KEY` / `NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY`.',
+    )
+  }
+
+  const issuer = `https://${frontendApiFromPublishableKey(key)}`
+
+  return {
+    resource: options.resource,
+    authorizationServers: [issuer],
+    jwt: {
+      jwks: `${issuer}/.well-known/jwks.json`,
+      issuer,
+      audience: false,
+      ...(options.authorizedParties ? { authorizedParties: options.authorizedParties } : {}),
+    },
+    scopesSupported: options.scopesSupported ?? CLERK_SCOPES,
+    authorizationServer: issuer,
+  }
+}

--- a/packages/nitro-mcp-toolkit/src/runtime/oauth/env.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/oauth/env.ts
@@ -1,0 +1,8 @@
+export function envValue(names: readonly string[]): string | undefined {
+  if (typeof process === 'undefined') return undefined
+
+  for (const name of names) {
+    const value = process.env[name]
+    if (typeof value === 'string' && value.trim() !== '') return value
+  }
+}

--- a/packages/nitro-mcp-toolkit/src/runtime/oauth/okta.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/oauth/okta.ts
@@ -1,0 +1,92 @@
+import { envValue } from './env.ts'
+import type { McpOAuthSetup } from '../oauth.ts'
+
+const DEFAULT_AUTH_SERVER = 'default'
+
+export interface OktaOAuthOptions {
+  /**
+   * This MCP endpoint as a resource identifier. Also the default access-token
+   * `aud` — set `audience` if the Okta API uses a different identifier.
+   *
+   * @example 'https://api.example.com/mcp'
+   */
+  resource: string
+  /**
+   * Okta hostname, not a URL. Builds `https://{domain}/oauth2/{authorizationServerId}`.
+   *
+   * @example 'acme.okta.com'
+   */
+  domain?: string
+  /**
+   * Full custom authorization server issuer.
+   *
+   * @example 'https://acme.okta.com/oauth2/default'
+   */
+  issuer?: string
+  /**
+   * Custom authorization server id when `domain` is set.
+   *
+   * @default 'default'
+   */
+  authorizationServerId?: string
+  /** Access-token `aud`. Defaults to `resource`. */
+  audience?: string | string[]
+  scopesSupported?: string[]
+}
+
+function issuerFromDomain(domain: string, authorizationServerId: string): string {
+  const host = domain.trim()
+
+  if (host.includes('/') || host.includes(':')) {
+    throw new Error(
+      '[nitro-mcp-toolkit] `okta` `domain` is a hostname (acme.okta.com). Pass `issuer` for a full authorization-server URL.',
+    )
+  }
+
+  return `https://${host}/oauth2/${authorizationServerId}`
+}
+
+/**
+ * Okta custom authorization server: JWKS at `{issuer}/v1/keys`, RFC 8414 at
+ * the path-style well-known URL. Org authorization servers issue opaque
+ * tokens — those still need `createMcpOAuth({ verify })`.
+ */
+export function okta(options: OktaOAuthOptions): McpOAuthSetup {
+  if (options.issuer && options.domain) {
+    throw new Error('[nitro-mcp-toolkit] `okta` takes `issuer` or `domain`, not both.')
+  }
+
+  const authorizationServerId = options.authorizationServerId ?? DEFAULT_AUTH_SERVER
+  const fromEnvDomain = envValue(['OKTA_DOMAIN'])
+  const issuer =
+    options.issuer ??
+    (options.domain ? issuerFromDomain(options.domain, authorizationServerId) : undefined) ??
+    envValue(['OKTA_ISSUER']) ??
+    (fromEnvDomain ? issuerFromDomain(fromEnvDomain, authorizationServerId) : undefined)
+
+  if (!issuer) {
+    throw new Error(
+      '[nitro-mcp-toolkit] `okta` needs `issuer` or `domain`, or `OKTA_ISSUER` / `OKTA_DOMAIN`.',
+    )
+  }
+
+  const normalized = issuer.replace(/\/+$/, '')
+
+  if (!normalized.includes('/oauth2/')) {
+    throw new Error(
+      '[nitro-mcp-toolkit] `okta` `issuer` must be a custom authorization server (`https://{domain}/oauth2/{id}`). Org-server tokens are opaque.',
+    )
+  }
+
+  return {
+    resource: options.resource,
+    authorizationServers: [normalized],
+    jwt: {
+      jwks: `${normalized}/v1/keys`,
+      issuer: normalized,
+      ...(options.audience !== undefined ? { audience: options.audience } : {}),
+    },
+    ...(options.scopesSupported ? { scopesSupported: options.scopesSupported } : {}),
+    authorizationServer: normalized,
+  }
+}

--- a/packages/nitro-mcp-toolkit/src/runtime/oauth/workos.ts
+++ b/packages/nitro-mcp-toolkit/src/runtime/oauth/workos.ts
@@ -1,0 +1,44 @@
+import { envValue } from './env.ts'
+import type { McpOAuthSetup } from '../oauth.ts'
+
+const ISSUER = 'https://api.workos.com'
+
+export interface WorkOSOAuthOptions {
+  /**
+   * This MCP endpoint as a resource identifier.
+   *
+   * @example 'https://api.example.com/mcp'
+   */
+  resource: string
+  /**
+   * WorkOS client id. Defaults to `WORKOS_CLIENT_ID`. Access-token `aud` is
+   * this client, not `resource`.
+   *
+   * @example 'client_123456789'
+   */
+  clientId?: string
+  scopesSupported?: string[]
+}
+
+/**
+ * WorkOS AuthKit session tokens: JWKS at `/sso/jwks/{clientId}`, `iss` is
+ * `https://api.workos.com`, `aud` is the client id.
+ */
+export function workos(options: WorkOSOAuthOptions): McpOAuthSetup {
+  const clientId = options.clientId ?? envValue(['WORKOS_CLIENT_ID'])
+
+  if (!clientId) {
+    throw new Error('[nitro-mcp-toolkit] `workos` needs `clientId`, or `WORKOS_CLIENT_ID`.')
+  }
+
+  return {
+    resource: options.resource,
+    authorizationServers: [ISSUER],
+    jwt: {
+      jwks: `${ISSUER}/sso/jwks/${clientId}`,
+      issuer: ISSUER,
+      audience: clientId,
+    },
+    ...(options.scopesSupported ? { scopesSupported: options.scopesSupported } : {}),
+  }
+}

--- a/packages/nitro-mcp-toolkit/test/module.test.ts
+++ b/packages/nitro-mcp-toolkit/test/module.test.ts
@@ -5,6 +5,7 @@ import { createNitro } from 'nitro/builder'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import mcp from '../src/module/index.ts'
 import { resolveOAuthOptions } from '../src/module/options.ts'
+import { clerk } from '../src/runtime/oauth/clerk.ts'
 import { fixtureDir, modules } from './helpers/discovery-fixture.ts'
 import type { Nitro } from 'nitro/types'
 
@@ -264,6 +265,45 @@ describe('the mcp() module', () => {
       })
       "
     `)
+
+    await guarded.close()
+  })
+
+  it('accepts a connector result and mounts RFC 8414 for old clients', async () => {
+    const key = `pk_test_${Buffer.from('acme.clerk.accounts.dev$', 'utf8').toString('base64')}`
+    const guarded = await createNitro({
+      rootDir: fixtureDir,
+      dev: false,
+      preset: 'standard',
+      modules: [
+        mcp({
+          route: '/mcp',
+          dir: 'server/mcp-admin',
+          oauth: clerk({
+            publishableKey: key,
+            resource: 'http://localhost:3030/mcp',
+          }),
+        }),
+      ],
+    })
+
+    expect(guarded.options.handlers).toMatchObject([
+      { route: '/mcp', handler: '#mcp/mcp/handler' },
+      {
+        route: '/.well-known/oauth-protected-resource/mcp',
+        handler: '#mcp/mcp/oauth-metadata',
+      },
+      {
+        route: '/.well-known/oauth-authorization-server',
+        handler: '#mcp/mcp/oauth-authorization-server',
+      },
+    ])
+
+    const generated = await render(guarded, '#mcp/mcp/oauth')
+    expect(generated).toContain('"https://acme.clerk.accounts.dev"')
+    expect(generated).toContain('https://acme.clerk.accounts.dev/.well-known/jwks.json')
+    expect(generated).toContain('"audience":false')
+    expect(generated).toContain('authorizationServer')
 
     await guarded.close()
   })

--- a/packages/nitro-mcp-toolkit/test/oauth-connectors.test.ts
+++ b/packages/nitro-mcp-toolkit/test/oauth-connectors.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { createMcpOAuth } from '../src/runtime/index.ts'
+import { clerk } from '../src/runtime/oauth/clerk.ts'
+import { okta } from '../src/runtime/oauth/okta.ts'
+import { workos } from '../src/runtime/oauth/workos.ts'
+
+const RESOURCE = 'https://api.example.com/mcp'
+
+function clerkKey(host = 'acme.clerk.accounts.dev'): string {
+  return `pk_test_${Buffer.from(`${host}$`, 'utf8').toString('base64')}`
+}
+
+function withoutEnv(names: string[], run: () => void): void {
+  const previous = names.map((name) => [name, process.env[name]] as const)
+
+  for (const name of names) delete process.env[name]
+
+  try {
+    run()
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) delete process.env[name]
+      else process.env[name] = value
+    }
+  }
+}
+
+describe('clerk', () => {
+  it('fills issuer and JWKS from a publishable key', () => {
+    const options = clerk({ resource: RESOURCE, publishableKey: clerkKey() })
+
+    expect(options.authorizationServers).toEqual(['https://acme.clerk.accounts.dev'])
+    expect(options.jwt).toEqual({
+      jwks: 'https://acme.clerk.accounts.dev/.well-known/jwks.json',
+      issuer: 'https://acme.clerk.accounts.dev',
+      audience: false,
+    })
+    expect(options.scopesSupported).toEqual(['openid', 'profile', 'email'])
+    expect(options.authorizationServer).toBe('https://acme.clerk.accounts.dev')
+  })
+
+  it('throws without a publishable key', () => {
+    withoutEnv(['CLERK_PUBLISHABLE_KEY', 'NUXT_PUBLIC_CLERK_PUBLISHABLE_KEY'], () => {
+      expect(() => clerk({ resource: RESOURCE })).toThrow(/publishableKey/)
+    })
+  })
+
+  it('refuses a non-Clerk key', () => {
+    expect(() => clerk({ resource: RESOURCE, publishableKey: 'sk_test_nope' })).toThrow(
+      /publishable key/,
+    )
+  })
+
+  it('is accepted by createMcpOAuth', () => {
+    const oauth = createMcpOAuth(clerk({ resource: RESOURCE, publishableKey: clerkKey() }))
+
+    expect(oauth.metadata.authorization_servers).toEqual(['https://acme.clerk.accounts.dev'])
+    expect(oauth.authorizationServerHandler).toBeTypeOf('function')
+  })
+})
+
+describe('okta', () => {
+  it('builds issuer and JWKS from a domain', () => {
+    const options = okta({ resource: RESOURCE, domain: 'acme.okta.com' })
+
+    expect(options.authorizationServers).toEqual(['https://acme.okta.com/oauth2/default'])
+    expect(options.jwt).toEqual({
+      jwks: 'https://acme.okta.com/oauth2/default/v1/keys',
+      issuer: 'https://acme.okta.com/oauth2/default',
+    })
+    expect(options.authorizationServer).toBe('https://acme.okta.com/oauth2/default')
+  })
+
+  it('accepts a full custom authorization-server issuer', () => {
+    const options = okta({
+      resource: RESOURCE,
+      issuer: 'https://acme.okta.com/oauth2/aus123',
+    })
+
+    expect(options.jwt?.jwks).toBe('https://acme.okta.com/oauth2/aus123/v1/keys')
+  })
+
+  it('refuses an org authorization server', () => {
+    expect(() => okta({ resource: RESOURCE, issuer: 'https://acme.okta.com' })).toThrow(/opaque/)
+  })
+
+  it('refuses a URL passed as domain', () => {
+    expect(() => okta({ resource: RESOURCE, domain: 'https://acme.okta.com' })).toThrow(/hostname/)
+  })
+
+  it('throws without issuer or domain', () => {
+    withoutEnv(['OKTA_ISSUER', 'OKTA_DOMAIN'], () => {
+      expect(() => okta({ resource: RESOURCE })).toThrow(/issuer` or `domain/)
+    })
+  })
+})
+
+describe('workos', () => {
+  it('verifies AuthKit tokens against the client JWKS', () => {
+    const options = workos({ resource: RESOURCE, clientId: 'client_abc' })
+
+    expect(options.authorizationServers).toEqual(['https://api.workos.com'])
+    expect(options.jwt).toEqual({
+      jwks: 'https://api.workos.com/sso/jwks/client_abc',
+      issuer: 'https://api.workos.com',
+      audience: 'client_abc',
+    })
+    expect(options.authorizationServer).toBeUndefined()
+  })
+
+  it('throws without a client id', () => {
+    withoutEnv(['WORKOS_CLIENT_ID'], () => {
+      expect(() => workos({ resource: RESOURCE })).toThrow(/clientId/)
+    })
+  })
+})

--- a/packages/nitro-mcp-toolkit/test/surface.test.ts
+++ b/packages/nitro-mcp-toolkit/test/surface.test.ts
@@ -53,4 +53,10 @@ describe('public exports', () => {
   it('does not load nitro-mcp-toolkit/servers outside mcp()', async () => {
     await expect(import('../src/runtime/servers.ts')).rejects.toThrow(/provided by `mcp\(\)`/)
   })
+
+  it('exposes oauth connectors on their own entries', async () => {
+    expect(Object.keys(await import('../src/runtime/oauth/clerk.ts')).sort()).toEqual(['clerk'])
+    expect(Object.keys(await import('../src/runtime/oauth/okta.ts')).sort()).toEqual(['okta'])
+    expect(Object.keys(await import('../src/runtime/oauth/workos.ts')).sort()).toEqual(['workos'])
+  })
 })


### PR DESCRIPTION
### 📚 Description

Stacked on #331. Last of the three OAuth PRs.

Each connector fills in one provider's issuer conventions and returns the same options object `mcp({ oauth })` and `createMcpOAuth` already accept, so using a provider is one call rather than a JWKS URL looked up by hand.

They sit on their own subpaths — `nitro-mcp-toolkit/oauth/clerk`, `/okta`, `/workos` — so an app that imports none of them never loads them.

- `clerk` reads `CLERK_PUBLISHABLE_KEY` for the issuer and JWKS, skips audience validation because Clerk puts the OAuth client in `azp` (use `authorizedParties` instead), and proxies RFC 8414 metadata for older clients that only look on the resource origin.
- `okta` covers custom authorization servers and derives JWKS from the issuer. Org-server tokens are opaque, so they are out of scope.
- `workos` covers AuthKit, where `aud` is the client id rather than the MCP URL.

Adds three `package.json` subpath exports and three build entries.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.